### PR TITLE
WriteAheadLog no. 2: Open, ReadAll

### DIFF
--- a/pkg/wal/util.go
+++ b/pkg/wal/util.go
@@ -6,9 +6,14 @@
 package wal
 
 import (
+	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/SmartBFT-Go/consensus/pkg/api"
 )
 
 var padTable [][]byte
@@ -56,12 +61,56 @@ func dirReadWalNames(dirPath string) ([]string, error) {
 	walNames := make([]string, 0)
 	for _, name := range names {
 		if strings.HasSuffix(name, walFileSuffix) {
+			var index uint64
+			n, err := fmt.Sscanf(name, walFileTemplate, &index)
+			if n != 1 || err != nil {
+				continue
+			}
 			walNames = append(walNames, name)
 		}
 	}
+
 	sort.Strings(walNames)
 
 	return walNames, nil
+}
+
+// checkWalFiles for continuous sequence, readable CRC-Anchor.
+// If the the last file cannot be read, it may be ignored,  (or repaired).
+func checkWalFiles(logger api.Logger, dirName string, walNames []string) ([]uint64, error) {
+	sort.Strings(walNames)
+	var indexes = make([]uint64, 0)
+	for i, name := range walNames {
+		index, err := parseWalFileName(name)
+		if err != nil {
+			logger.Errorf("wal: failed to parse file name: %s; error: %s", name, err)
+			return nil, err
+		}
+		indexes = append(indexes, index)
+
+		// verify we have CRC-Anchor.
+		// TODO BACKLOG check if it is the last file and return a special error that allows a repair.
+		r, err := NewLogRecordReader(logger, filepath.Join(dirName, walNames[i]))
+		if err != nil {
+			logger.Errorf("wal: failed to create reader for file: %s; error: %s", name, err)
+			return nil, err
+		}
+		err = r.Close()
+		if err != nil {
+			logger.Errorf("wal: failed to close reader for file: %s; error: %s", name, err)
+			return nil, err
+		}
+
+		//verify no gaps
+		if i == 0 {
+			continue
+		}
+		if index != (indexes[i-1] + 1) {
+			return nil, errors.New("wal: files not in sequence")
+		}
+	}
+
+	return indexes, nil
 }
 
 func getPadSize(recordLength int) int {
@@ -71,4 +120,12 @@ func getPadSize(recordLength int) int {
 func getPadBytes(recordLength int) (int, []byte) {
 	i := getPadSize(recordLength)
 	return i, padTable[i]
+}
+
+func parseWalFileName(fileName string) (index uint64, err error) {
+	n, err := fmt.Sscanf(fileName, walFileTemplate, &index)
+	if n != 1 || err != nil {
+		return 0, fmt.Errorf("failed to parse wal file name: %s; error: %s", fileName, err)
+	}
+	return index, nil
 }

--- a/pkg/wal/util_test.go
+++ b/pkg/wal/util_test.go
@@ -1,0 +1,6 @@
+// Copyright IBM Corp. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package wal


### PR DESCRIPTION
Impelement:
 - Open(): opening an existing WAL
 - ReadAll(): reading all the data items from a truncation
   point to the end of the WAL.

Fixes:
 - readHeader & readPayload now use io.ReadFull, to detect
   short reads.

Signed-off-by: Yoav Tock <tock@il.ibm.com>