### PR TITLE
Pass thru batching and timeout parameters

### DIFF
--- a/examples/naive_chain/node.go
+++ b/examples/naive_chain/node.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"sync/atomic"
+	"time"
 
 	smart "github.com/SmartBFT-Go/consensus/pkg/api"
 	smartbft "github.com/SmartBFT-Go/consensus/pkg/consensus"
@@ -131,6 +132,8 @@ func NewNode(id uint64, in Ingress, out Egress, deliverChan chan<- *Block, logge
 	node.consensus = &smartbft.Consensus{
 		SelfID:           id,
 		N:                4,
+		BatchSize:        1,
+		BatchTimeout:     10 * time.Millisecond,
 		Logger:           logger,
 		Comm:             node,
 		Signer:           node,

--- a/internal/bft/batcher.go
+++ b/internal/bft/batcher.go
@@ -10,10 +10,10 @@ import (
 )
 
 type Bundler struct { // TODO change name
-	Pool      RequestPool
-	BatchSize int
-	Timeout   time.Duration
-	remainder [][]byte
+	Pool         RequestPool
+	BatchSize    int
+	BatchTimeout time.Duration
+	remainder    [][]byte
 }
 
 // NextBatch returns the next batch of requests to be proposed
@@ -24,7 +24,7 @@ func (b *Bundler) NextBatch() [][]byte {
 		currBatch = b.remainder
 	}
 	b.remainder = make([][]byte, 0)
-	timeout := time.After(b.Timeout)
+	timeout := time.After(b.BatchTimeout)
 	for {
 		select {
 		case <-timeout:
@@ -33,7 +33,7 @@ func (b *Bundler) NextBatch() [][]byte {
 			if b.Pool.SizeOfPool() >= b.BatchSize-remainderOccupied {
 				return b.buildBatch(remainderOccupied, currBatch)
 			}
-			time.Sleep(b.Timeout / 100)
+			time.Sleep(b.BatchTimeout / 100)
 		}
 	}
 }

--- a/internal/bft/batcher_test.go
+++ b/internal/bft/batcher_test.go
@@ -38,9 +38,9 @@ func TestBatcherBasic(t *testing.T) {
 	assert.NoError(t, err)
 
 	batcher := bft.Bundler{
-		Pool:      &pool,
-		BatchSize: 1,
-		Timeout:   10 * time.Millisecond,
+		Pool:         &pool,
+		BatchSize:    1,
+		BatchTimeout: 10 * time.Millisecond,
 	}
 
 	res := batcher.NextBatch()
@@ -83,9 +83,9 @@ func TestBatcherBasic(t *testing.T) {
 	assert.Equal(t, byteReq3, res[0])
 
 	batcher = bft.Bundler{
-		Pool:      &pool,
-		BatchSize: 2,
-		Timeout:   10 * time.Millisecond,
+		Pool:         &pool,
+		BatchSize:    2,
+		BatchTimeout: 10 * time.Millisecond,
 	}
 
 	batcher.BatchRemainder([][]byte{byteReq1})
@@ -119,9 +119,9 @@ func TestBatcherWhileSubmitting(t *testing.T) {
 	pool.Start()
 
 	batcher := bft.Bundler{
-		Pool:      &pool,
-		BatchSize: 100,
-		Timeout:   100 * time.Second, // long time
+		Pool:         &pool,
+		BatchSize:    100,
+		BatchTimeout: 100 * time.Second, // long time
 	}
 
 	rem := make([][]byte, 0)

--- a/pkg/consensus/consensus.go
+++ b/pkg/consensus/consensus.go
@@ -21,6 +21,8 @@ import (
 type Consensus struct {
 	SelfID           uint64
 	N                uint64
+	BatchSize        int
+	BatchTimeout     time.Duration
 	Application      bft.Application
 	Comm             bft.Comm
 	Assembler        bft.Assembler
@@ -62,9 +64,9 @@ func (c *Consensus) Start() Future {
 	pool.Start()
 
 	batcher := &algorithm.Bundler{
-		Pool:      pool,
-		BatchSize: 1,
-		Timeout:   10 * time.Millisecond,
+		Pool:         pool,
+		BatchSize:    c.BatchSize,
+		BatchTimeout: c.BatchTimeout,
 	}
 
 	c.controller = &algorithm.Controller{


### PR DESCRIPTION
There is a need to be able to configure batching parameters, such as batch size and batch timeout.
Signed-off-by: Artem Barger <bartem@il.ibm.com>