### PR TITLE
Update Comm dependency to align with architecture

### DIFF
--- a/examples/naive_chain/node.go
+++ b/examples/naive_chain/node.go
@@ -89,7 +89,7 @@ func (n *Node) AssembleProposal(metadata []byte, requests [][]byte) (nextProp bf
 	}, nil
 }
 
-func (n *Node) Broadcast(m *protos.Message) {
+func (n *Node) BroadcastConsensus(m *protos.Message) {
 	for receiver, out := range n.out {
 		if n.id == uint64(receiver) {
 			continue
@@ -98,7 +98,11 @@ func (n *Node) Broadcast(m *protos.Message) {
 	}
 }
 
-func (n *Node) Send(targetID uint64, message *protos.Message) {
+func (n *Node) SendConsensus(targetID uint64, message *protos.Message) {
+	n.out[int(targetID)] <- message
+}
+
+func (n *Node) SendTransaction(targetID uint64, message *protos.Message) {
 	n.out[int(targetID)] <- message
 }
 

--- a/internal/bft/controller.go
+++ b/internal/bft/controller.go
@@ -58,7 +58,7 @@ type Synchronizer interface {
 
 //go:generate mockery -dir . -name Comm -case underscore -output ./mocks/
 type Comm interface {
-	Broadcast(m *protos.Message)
+	BroadcastConsensus(m *protos.Message)
 }
 
 //go:generate mockery -dir . -name Signer -case underscore -output ./mocks/

--- a/internal/bft/controller_test.go
+++ b/internal/bft/controller_test.go
@@ -60,7 +60,7 @@ func TestQuorum(t *testing.T) {
 			verifier := &mocks.Verifier{}
 			verifier.On("VerifyProposal", mock.Anything, mock.Anything).Return(nil, nil)
 			comm := &mocks.Comm{}
-			comm.On("Broadcast", mock.Anything)
+			comm.On("BroadcastConsensus", mock.Anything)
 			basicLog, err := zap.NewDevelopment()
 			assert.NoError(t, err)
 			verifyLog := make(chan struct{}, 1)
@@ -125,7 +125,7 @@ func TestLeaderPropose(t *testing.T) {
 	assembler.On("AssembleProposal", mock.Anything, [][]byte{req}).Return(proposal, [][]byte{})
 	comm := &mocks.Comm{}
 	commWG := sync.WaitGroup{}
-	comm.On("Broadcast", mock.Anything).Run(func(args mock.Arguments) {
+	comm.On("BroadcastConsensus", mock.Anything).Run(func(args mock.Arguments) {
 		commWG.Done()
 	})
 	signer := &mocks.Signer{}
@@ -188,7 +188,7 @@ func TestLeaderChange(t *testing.T) {
 	assembler.On("AssembleProposal", mock.Anything, [][]byte{req}).Return(proposal, [][]byte{})
 	comm := &mocks.Comm{}
 	commWG := sync.WaitGroup{}
-	comm.On("Broadcast", mock.Anything).Run(func(args mock.Arguments) {
+	comm.On("BroadcastConsensus", mock.Anything).Run(func(args mock.Arguments) {
 		commWG.Done()
 	})
 	synchronizer := &mocks.Synchronizer{}
@@ -230,7 +230,7 @@ func TestLeaderChange(t *testing.T) {
 	batcher.AssertNumberOfCalls(t, "NextBatch", 1)
 	verifier.AssertNumberOfCalls(t, "VerifyRequest", 1)
 	assembler.AssertNumberOfCalls(t, "AssembleProposal", 1)
-	comm.AssertNumberOfCalls(t, "Broadcast", 2)
+	comm.AssertNumberOfCalls(t, "BroadcastConsensus", 2)
 	controller.Stop()
 	end.Wait()
 }

--- a/internal/bft/mocks/comm.go
+++ b/internal/bft/mocks/comm.go
@@ -10,7 +10,7 @@ type Comm struct {
 	mock.Mock
 }
 
-// Broadcast provides a mock function with given fields: m
-func (_m *Comm) Broadcast(m *smartbftprotos.Message) {
+// BroadcastConsensus provides a mock function with given fields: m
+func (_m *Comm) BroadcastConsensus(m *smartbftprotos.Message) {
 	_m.Called(m)
 }

--- a/internal/bft/view.go
+++ b/internal/bft/view.go
@@ -240,10 +240,10 @@ func (v *View) run() {
 func (v *View) doPhase() {
 	switch v.Phase {
 	case PROPOSED:
-		v.Comm.Broadcast(v.lastBroadcastSent)
+		v.Comm.BroadcastConsensus(v.lastBroadcastSent)
 		v.Phase = v.processPrepares()
 	case PREPARED:
-		v.Comm.Broadcast(v.lastBroadcastSent)
+		v.Comm.BroadcastConsensus(v.lastBroadcastSent)
 		v.Phase = v.prepared()
 	default:
 		v.Phase = v.processProposal()
@@ -319,7 +319,7 @@ func (v *View) processProposal() Phase {
 	v.inFlightRequests = requests
 
 	if v.ID == v.LeaderID {
-		v.Comm.Broadcast(receivedProposal)
+		v.Comm.BroadcastConsensus(receivedProposal)
 	}
 
 	v.Logger.Infof("Processed proposal with seq %d", seq)

--- a/internal/bft/view_test.go
+++ b/internal/bft/view_test.go
@@ -7,11 +7,10 @@ package bft_test
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
-
-	"fmt"
 
 	"github.com/SmartBFT-Go/consensus/internal/bft"
 	"github.com/SmartBFT-Go/consensus/internal/bft/mocks"
@@ -226,7 +225,7 @@ func TestBadPrepare(t *testing.T) {
 	})
 	comm := &mocks.Comm{}
 	commWG := sync.WaitGroup{}
-	comm.On("Broadcast", mock.Anything).Run(func(args mock.Arguments) {
+	comm.On("BroadcastConsensus", mock.Anything).Run(func(args mock.Arguments) {
 		commWG.Done()
 	})
 	verifier := &mocks.Verifier{}
@@ -312,7 +311,7 @@ func TestBadCommit(t *testing.T) {
 		return nil
 	})).Sugar()
 	comm := &mocks.Comm{}
-	comm.On("Broadcast", mock.Anything)
+	comm.On("BroadcastConsensus", mock.Anything)
 	verifier := &mocks.Verifier{}
 	verifier.On("VerifyProposal", mock.Anything, mock.Anything).Return(nil, nil)
 	verifier.On("VerifyConsenterSig", mock.Anything, mock.Anything, mock.Anything).Return(errors.New(""))
@@ -364,7 +363,7 @@ func TestNormalPath(t *testing.T) {
 	log := basicLog.Sugar()
 	comm := &mocks.Comm{}
 	commWG := sync.WaitGroup{}
-	comm.On("Broadcast", mock.Anything).Run(func(args mock.Arguments) {
+	comm.On("BroadcastConsensus", mock.Anything).Run(func(args mock.Arguments) {
 		fmt.Println("Sending", args.Get(0))
 		commWG.Done()
 	})
@@ -477,7 +476,7 @@ func TestTwoSequences(t *testing.T) {
 	log := basicLog.Sugar()
 	comm := &mocks.Comm{}
 	commWG := sync.WaitGroup{}
-	comm.On("Broadcast", mock.Anything).Run(func(args mock.Arguments) {
+	comm.On("BroadcastConsensus", mock.Anything).Run(func(args mock.Arguments) {
 		commWG.Done()
 	})
 	decider := &mocks.Decider{}

--- a/pkg/api/dependencies.go
+++ b/pkg/api/dependencies.go
@@ -15,8 +15,9 @@ type Application interface {
 }
 
 type Comm interface {
-	Broadcast(m *protos.Message) // broadcast message to others (not including yourself)
-	Send(targetID uint64, message *protos.Message)
+	BroadcastConsensus(m *protos.Message) // broadcast message to others (not including yourself)
+	SendConsensus(targetID uint64, m *protos.Message)
+	SendTransaction(targetID uint64, m *protos.Message)
 }
 
 type Assembler interface {


### PR DESCRIPTION
This commit refactors Comm interface to conform with documentation:

1. Rename Broadcast API into BroadcastConsensus
2. Split Send into SendTransaction and SendConsensus

Update mocks and unit test accordingly.

Signed-off-by: Artem Barger <bartem@il.ibm.com>