### PR TITLE
Fix bft.Comm dependency API

### DIFF
--- a/examples/naive_chain/node.go
+++ b/examples/naive_chain/node.go
@@ -102,8 +102,8 @@ func (n *Node) SendConsensus(targetID uint64, message *protos.Message) {
 	n.out[int(targetID)] <- message
 }
 
-func (n *Node) SendTransaction(targetID uint64, message *protos.Message) {
-	n.out[int(targetID)] <- message
+func (n *Node) SendTransaction(targetID uint64, request []byte) {
+	// TODO: Handle send transaction request
 }
 
 func (n *Node) Deliver(proposal bft.Proposal, signature []bft.Signature) {

--- a/pkg/api/dependencies.go
+++ b/pkg/api/dependencies.go
@@ -17,7 +17,7 @@ type Application interface {
 type Comm interface {
 	BroadcastConsensus(m *protos.Message) // broadcast message to others (not including yourself)
 	SendConsensus(targetID uint64, m *protos.Message)
-	SendTransaction(targetID uint64, m *protos.Message)
+	SendTransaction(targetID uint64, request []byte)
 }
 
 type Assembler interface {


### PR DESCRIPTION
Change SendTransaction API of bft package to receive slice of bytes and
not proto message.

Signed-off-by: Artem Barger <bartem@il.ibm.com>