### PR TITLE
Rename request pool Start into NewPool

### DIFF
--- a/internal/bft/batcher_test.go
+++ b/internal/bft/batcher_test.go
@@ -28,17 +28,12 @@ func TestBatcherBasic(t *testing.T) {
 	insp.On("RequestID", byteReq2).Return(types.RequestInfo{ID: "2", ClientID: "2"})
 	byteReq3 := []byte{3}
 	insp.On("RequestID", byteReq3).Return(types.RequestInfo{ID: "3", ClientID: "3"})
-	pool := bft.Pool{
-		Log:              log,
-		RequestInspector: insp,
-		QueueSize:        3,
-	}
-	pool.Start()
+	pool := bft.NewPool(log, insp, 3)
 	err = pool.Submit(byteReq1)
 	assert.NoError(t, err)
 
 	batcher := bft.Bundler{
-		Pool:         &pool,
+		Pool:         pool,
 		BatchSize:    1,
 		BatchTimeout: 10 * time.Millisecond,
 	}
@@ -83,7 +78,7 @@ func TestBatcherBasic(t *testing.T) {
 	assert.Equal(t, byteReq3, res[0])
 
 	batcher = bft.Bundler{
-		Pool:         &pool,
+		Pool:         pool,
 		BatchSize:    2,
 		BatchTimeout: 10 * time.Millisecond,
 	}
@@ -111,15 +106,10 @@ func TestBatcherWhileSubmitting(t *testing.T) {
 	assert.NoError(t, err)
 	log := basicLog.Sugar()
 	insp := &mocks.RequestInspector{}
-	pool := bft.Pool{
-		Log:              log,
-		RequestInspector: insp,
-		QueueSize:        200,
-	}
-	pool.Start()
+	pool := bft.NewPool(log, insp, 200)
 
 	batcher := bft.Bundler{
-		Pool:         &pool,
+		Pool:         pool,
 		BatchSize:    100,
 		BatchTimeout: 100 * time.Second, // long time
 	}

--- a/internal/bft/requestpool_test.go
+++ b/internal/bft/requestpool_test.go
@@ -24,12 +24,8 @@ func TestReqPoolBasic(t *testing.T) {
 	insp := &mocks.RequestInspector{}
 	byteReq1 := []byte{1}
 	insp.On("RequestID", byteReq1).Return(types.RequestInfo{ID: "1", ClientID: "1"})
-	pool := bft.Pool{
-		Log:              log,
-		RequestInspector: insp,
-		QueueSize:        3,
-	}
-	pool.Start()
+	pool := bft.NewPool(log, insp, 3)
+
 	assert.Equal(t, 0, pool.SizeOfPool())
 	err = pool.Submit(byteReq1)
 	assert.NoError(t, err)
@@ -121,12 +117,8 @@ func TestEventuallySubmit(t *testing.T) {
 	assert.NoError(t, err)
 	log := basicLog.Sugar()
 	insp := &mocks.RequestInspector{}
-	pool := bft.Pool{
-		Log:              log,
-		RequestInspector: insp,
-		QueueSize:        50,
-	}
-	pool.Start()
+	pool := bft.NewPool(log, insp, 50)
+
 	wg := sync.WaitGroup{}
 	wg.Add(2 * n)
 	for i := 0; i < n; i++ {

--- a/pkg/consensus/consensus.go
+++ b/pkg/consensus/consensus.go
@@ -55,12 +55,7 @@ type Future interface {
 }
 
 func (c *Consensus) Start() Future {
-	pool := &algorithm.Pool{
-		Log:              c.Logger,
-		RequestInspector: c.RequestInspector,
-		QueueSize:        200,
-	}
-	pool.Start()
+	pool := algorithm.NewPool(c.Logger, c.RequestInspector, 200)
 
 	batcher := &algorithm.Bundler{
 		Pool:         pool,


### PR DESCRIPTION
Currently request pool introduces a function Start which basically
initializes the structure. This commit renames it to better reflect its
purpose (adding a few godocs).

Signed-off-by: Artem Barger <bartem@il.ibm.com>