### PR TITLE
RequestPool: Fix concurrency bug

### DIFF
--- a/internal/bft/requestpool.go
+++ b/internal/bft/requestpool.go
@@ -33,9 +33,9 @@ type Pool struct {
 
 // Request captures request related information
 type Request struct {
+	ClientID string
 	ID       string
 	Request  []byte
-	ClientID string
 }
 
 // NewPool constructs new requests pool
@@ -85,14 +85,17 @@ func (rp *Pool) SizeOfPool() int {
 	return len(rp.queue)
 }
 
-// NextRequests return the next requests to be batched
+// NextRequests returns the next requests to be batched.
+// It returns at most n request, in a newly allocated slice.
 func (rp *Pool) NextRequests(n int) []Request {
 	rp.lock.RLock()
 	defer rp.lock.RUnlock()
-	if len(rp.queue) <= n {
-		return rp.queue
-	}
-	return rp.queue[:n]
+
+	m := minInt(len(rp.queue), n)
+	buff := make([]Request, m)
+	copy(buff, rp.queue[:m])
+
+	return buff
 }
 
 // RemoveRequest removes the given request from the pool

--- a/internal/bft/util.go
+++ b/internal/bft/util.go
@@ -46,3 +46,10 @@ func proposalSequence(m *protos.Message) uint64 {
 
 	return math.MaxUint64
 }
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
The NextRequests method returns a re-slice of the internal slice
that must be guarded by a mutex.

Signed-off-by: Yoav Tock <tock@il.ibm.com>