### PR TITLE
Request time-out: skeleton

### DIFF
--- a/examples/naive_chain/chain.go
+++ b/examples/naive_chain/chain.go
@@ -93,6 +93,6 @@ func (chain *Chain) Listen() Block {
 	return *block
 }
 
-func (chain *Chain) Order(txn Transaction) {
-	chain.node.consensus.SubmitRequest(txn.ToBytes())
+func (chain *Chain) Order(txn Transaction) error {
+	return chain.node.consensus.SubmitRequest(txn.ToBytes())
 }

--- a/examples/naive_chain/chain_test.go
+++ b/examples/naive_chain/chain_test.go
@@ -65,16 +65,17 @@ func TestBlockHeader(t *testing.T) {
 }
 
 func TestChain(t *testing.T) {
-	blockCount := 100
+	blockCount := 10
 
 	chains := setupNetwork(t, 4)
 
 	for blockSeq := 0; blockSeq < blockCount; blockSeq++ {
 		for _, chain := range chains {
-			chain.Order(Transaction{
+			err := chain.Order(Transaction{
 				ClientID: "alice",
 				Id:       fmt.Sprintf("tx%d", blockSeq),
 			})
+			assert.NoError(t, err)
 		}
 	}
 

--- a/internal/bft/requestpool.go
+++ b/internal/bft/requestpool.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/SmartBFT-Go/consensus/pkg/api"
 	"github.com/SmartBFT-Go/consensus/pkg/types"
 	"golang.org/x/sync/semaphore"
 )
@@ -23,7 +24,7 @@ type RequestInspector interface {
 // construction. In case there are more incoming request than given size it will
 // block during submit until there will be place to submit new ones.
 type Pool struct {
-	Log              Logger
+	Log              api.Logger
 	RequestInspector RequestInspector
 	queue            []Request
 	semaphore        *semaphore.Weighted
@@ -40,7 +41,7 @@ type Request struct {
 
 // NewPool constructs new requests pool
 func NewPool(
-	log Logger,
+	log api.Logger,
 	inspector RequestInspector,
 	queueSize int64,
 ) *Pool {

--- a/internal/bft/state.go
+++ b/internal/bft/state.go
@@ -28,7 +28,7 @@ func (*StateRecorder) Restore(_ *View) error {
 }
 
 type PersistedState struct {
-	Logger Logger
+	Logger api.Logger
 	WAL    api.WriteAheadLog
 }
 
@@ -88,7 +88,7 @@ func (ps *PersistedState) Restore(v *View) error {
 	return nil
 }
 
-func recoverProposed(lastPersistedMessage *smartbftprotos.Message, v *View, logger Logger) error {
+func recoverProposed(lastPersistedMessage *smartbftprotos.Message, v *View, logger api.Logger) error {
 	prop := lastPersistedMessage.GetPrePrepare().Proposal
 	v.inFlightProposal = &types.Proposal{
 		VerificationSequence: int64(prop.VerificationSequence),
@@ -112,7 +112,7 @@ func recoverProposed(lastPersistedMessage *smartbftprotos.Message, v *View, logg
 	return nil
 }
 
-func recoverPrepared(lastPersistedMessage *smartbftprotos.Message, v *View, entries [][]byte, logger Logger) error {
+func recoverPrepared(lastPersistedMessage *smartbftprotos.Message, v *View, entries [][]byte, logger api.Logger) error {
 	// Last entry is a commit, so we should have not pruned the previous pre-prepare
 	if len(entries) < 2 {
 		return fmt.Errorf("last message is a commit, but expected to also have a matching pre-prepare")

--- a/internal/bft/view.go
+++ b/internal/bft/view.go
@@ -8,6 +8,7 @@ package bft
 import (
 	"sync"
 
+	"github.com/SmartBFT-Go/consensus/pkg/api"
 	"github.com/SmartBFT-Go/consensus/pkg/types"
 	protos "github.com/SmartBFT-Go/consensus/smartbftprotos"
 	"github.com/golang/protobuf/proto"
@@ -43,7 +44,7 @@ type View struct {
 	Decider          Decider
 	FailureDetector  FailureDetector
 	Sync             Synchronizer
-	Logger           Logger
+	Logger           api.Logger
 	Comm             Comm
 	Verifier         Verifier
 	Signer           Signer

--- a/pkg/consensus/consensus.go
+++ b/pkg/consensus/consensus.go
@@ -64,19 +64,20 @@ func (c *Consensus) Start() Future {
 	}
 
 	c.controller = &algorithm.Controller{
-		WAL:             c.WAL,
-		ID:              c.SelfID,
-		N:               c.N,
-		Batcher:         batcher,
-		RequestPool:     pool,
-		Verifier:        c.Verifier,
-		Logger:          c.Logger,
-		Assembler:       c.Assembler,
-		Application:     c,
-		FailureDetector: c,
-		Synchronizer:    c,
-		Comm:            c.Comm,
-		Signer:          c.Signer,
+		WAL:              c.WAL,
+		ID:               c.SelfID,
+		N:                c.N,
+		Batcher:          batcher,
+		RequestPool:      pool,
+		Verifier:         c.Verifier,
+		Logger:           c.Logger,
+		Assembler:        c.Assembler,
+		Application:      c,
+		FailureDetector:  c,
+		Synchronizer:     c,
+		Comm:             c.Comm,
+		Signer:           c.Signer,
+		RequestInspector: c.RequestInspector,
 	}
 	future := c.controller.Start(0, 0)
 	return future
@@ -89,6 +90,7 @@ func (c *Consensus) HandleMessage(sender uint64, m *protos.Message) {
 
 }
 
-func (c *Consensus) SubmitRequest(req []byte) {
-	c.controller.SubmitRequest(req)
+func (c *Consensus) SubmitRequest(req []byte) error {
+	c.Logger.Debugf("Submit Request")
+	return c.controller.SubmitRequest(req)
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -30,6 +30,10 @@ type RequestInfo struct {
 	ClientID string
 }
 
+func (r *RequestInfo) String() string {
+	return r.ClientID + ":" + r.ID
+}
+
 func (p Proposal) Digest() string {
 	rawBytes, err := asn1.Marshal(Proposal{
 		VerificationSequence: p.VerificationSequence,


### PR DESCRIPTION
- Identify where timeouts are triggered and handled
- Change signature of SubmitRequest to return error,
  in case the Submit to the RequestPool times out or
  returns an error

Signed-off-by: Yoav Tock <tock@il.ibm.com>