### PR TITLE
Support: seperate internal dependencies definitions

### DIFF
--- a/internal/bft/controller.go
+++ b/internal/bft/controller.go
@@ -16,24 +16,6 @@ import (
 	protos "github.com/SmartBFT-Go/consensus/smartbftprotos"
 )
 
-//go:generate mockery -dir . -name Verifier -case underscore -output ./mocks/
-type Verifier interface {
-	VerifyProposal(proposal types.Proposal, prevHeader []byte) ([]types.RequestInfo, error)
-	VerifyRequest(val []byte) (types.RequestInfo, error)
-	VerifyConsenterSig(signature types.Signature, prop types.Proposal) error
-	VerificationSequence() uint64
-}
-
-//go:generate mockery -dir . -name Assembler -case underscore -output ./mocks/
-type Assembler interface {
-	AssembleProposal(metadata []byte, requests [][]byte) (nextProp types.Proposal, remainder [][]byte)
-}
-
-//go:generate mockery -dir . -name Application -case underscore -output ./mocks/
-type Application interface {
-	Deliver(proposal types.Proposal, signature []types.Signature)
-}
-
 //go:generate mockery -dir . -name Decider -case underscore -output ./mocks/
 type Decider interface {
 	Decide(proposal types.Proposal, signatures []types.Signature, requests []types.RequestInfo)
@@ -42,22 +24,6 @@ type Decider interface {
 //go:generate mockery -dir . -name FailureDetector -case underscore -output ./mocks/
 type FailureDetector interface {
 	Complain()
-}
-
-//go:generate mockery -dir . -name Synchronizer -case underscore -output ./mocks/
-type Synchronizer interface {
-	Sync() (protos.ViewMetadata, uint64)
-}
-
-//go:generate mockery -dir . -name Comm -case underscore -output ./mocks/
-type Comm interface {
-	BroadcastConsensus(m *protos.Message)
-}
-
-//go:generate mockery -dir . -name Signer -case underscore -output ./mocks/
-type Signer interface {
-	Sign([]byte) []byte
-	SignProposal(types.Proposal) *types.Signature
 }
 
 //go:generate mockery -dir . -name Batcher -case underscore -output ./mocks/

--- a/internal/bft/mocks/comm.go
+++ b/internal/bft/mocks/comm.go
@@ -14,3 +14,13 @@ type Comm struct {
 func (_m *Comm) BroadcastConsensus(m *smartbftprotos.Message) {
 	_m.Called(m)
 }
+
+// SendConsensus provides a mock function with given fields: targetID, m
+func (_m *Comm) SendConsensus(targetID uint64, m *smartbftprotos.Message) {
+	_m.Called(targetID, m)
+}
+
+// SendTransaction provides a mock function with given fields: targetID, request
+func (_m *Comm) SendTransaction(targetID uint64, request []byte) {
+	_m.Called(targetID, request)
+}

--- a/internal/bft/support.go
+++ b/internal/bft/support.go
@@ -1,0 +1,49 @@
+// Copyright IBM Corp. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package bft
+
+import (
+	"github.com/SmartBFT-Go/consensus/pkg/types"
+	protos "github.com/SmartBFT-Go/consensus/smartbftprotos"
+)
+
+// A collection of interfaces that are also defined in api/dependencies.go
+
+//go:generate mockery -dir . -name Verifier -case underscore -output ./mocks/
+type Verifier interface {
+	VerifyProposal(proposal types.Proposal, prevHeader []byte) ([]types.RequestInfo, error)
+	VerifyRequest(val []byte) (types.RequestInfo, error)
+	VerifyConsenterSig(signature types.Signature, prop types.Proposal) error
+	VerificationSequence() uint64
+}
+
+//go:generate mockery -dir . -name Assembler -case underscore -output ./mocks/
+type Assembler interface {
+	AssembleProposal(metadata []byte, requests [][]byte) (nextProp types.Proposal, remainder [][]byte)
+}
+
+//go:generate mockery -dir . -name Application -case underscore -output ./mocks/
+type Application interface {
+	Deliver(proposal types.Proposal, signature []types.Signature)
+}
+
+//go:generate mockery -dir . -name Comm -case underscore -output ./mocks/
+type Comm interface {
+	BroadcastConsensus(m *protos.Message)
+	SendConsensus(targetID uint64, m *protos.Message)
+	SendTransaction(targetID uint64, request []byte)
+}
+
+//go:generate mockery -dir . -name Synchronizer -case underscore -output ./mocks/
+type Synchronizer interface {
+	Sync() (protos.ViewMetadata, uint64)
+}
+
+//go:generate mockery -dir . -name Signer -case underscore -output ./mocks/
+type Signer interface {
+	Sign([]byte) []byte
+	SignProposal(types.Proposal) *types.Signature
+}


### PR DESCRIPTION
- Seperate the interface definitions of dependencies into a
  separate file, to clean up controller.go.

- Update the Comm interface with two Send* methods

Signed-off-by: Yoav Tock <tock@il.ibm.com>