### PR TITLE
Include verification sqn in RequestPool API

### DIFF
--- a/internal/bft/batcher.go
+++ b/internal/bft/batcher.go
@@ -42,7 +42,7 @@ func (b *Bundler) NextBatch() [][]byte {
 func (b *Bundler) buildBatch(remainderOccupied int, currBatch [][]byte) [][]byte {
 	reqs := b.Pool.NextRequests(b.BatchSize - remainderOccupied)
 	for i := 0; i < len(reqs); i++ {
-		currBatch = append(currBatch, reqs[i])
+		currBatch = append(currBatch, reqs[i].Request)
 	}
 	return currBatch
 }

--- a/internal/bft/batcher_test.go
+++ b/internal/bft/batcher_test.go
@@ -26,7 +26,7 @@ func TestBatcherBasic(t *testing.T) {
 	byteReq2 := makeTestRequest("2", "2", "foo")
 	byteReq3 := makeTestRequest("3", "3", "foo")
 	pool := bft.NewPool(log, insp, 3, 0)
-	err = pool.Submit(byteReq1)
+	err = pool.Submit(byteReq1, 0)
 	assert.NoError(t, err)
 
 	batcher := bft.Bundler{
@@ -48,9 +48,9 @@ func TestBatcherBasic(t *testing.T) {
 	res = batcher.NextBatch()
 	assert.Len(t, res, 0) // after timeout
 
-	err = pool.Submit(byteReq2)
+	err = pool.Submit(byteReq2, 0)
 	assert.NoError(t, err)
-	err = pool.Submit(byteReq3)
+	err = pool.Submit(byteReq3, 0)
 	assert.NoError(t, err)
 
 	batcher.BatchRemainder([][]byte{byteReq1})
@@ -82,7 +82,7 @@ func TestBatcherBasic(t *testing.T) {
 
 	batcher.BatchRemainder([][]byte{byteReq1})
 
-	err = pool.Submit(byteReq2)
+	err = pool.Submit(byteReq2, 0)
 	assert.NoError(t, err)
 
 	res = batcher.NextBatch()
@@ -123,7 +123,7 @@ func TestBatcherWhileSubmitting(t *testing.T) {
 		for i := 0; i < 100; i++ {
 			iStr := fmt.Sprintf("%d", i)
 			byteReq := makeTestRequest(iStr, iStr, "foo")
-			err := pool.Submit(byteReq)
+			err := pool.Submit(byteReq, 0)
 			assert.NoError(t, err)
 		}
 	}()

--- a/internal/bft/controller.go
+++ b/internal/bft/controller.go
@@ -33,9 +33,9 @@ type Batcher interface {
 }
 
 type RequestPool interface {
-	Submit(request []byte) error
+	Submit(request []byte, verificationSequence uint64) error
 	Size() int
-	NextRequests(n int) [][]byte
+	NextRequests(n int) []NextRequest
 	RemoveRequest(request types.RequestInfo) error
 }
 
@@ -95,7 +95,7 @@ func (c *Controller) computeQuorum() int {
 func (c *Controller) SubmitRequest(request []byte) error {
 	info := c.RequestInspector.RequestID(request)
 
-	err := c.RequestPool.Submit(request)
+	err := c.RequestPool.Submit(request, 0)
 	if err != nil {
 		c.Logger.Warnf("Request %s was not submitted, error: %s", info, err)
 		return err


### PR DESCRIPTION
- submit a request with verficationSequence uint64
- retrive next requests with slice of tuple <[]byte,uint64>
  that includes the request and the verficationSequence it
  was submitted with.

Signed-off-by: Yoav Tock <tock@il.ibm.com>