### PR TITLE
Timeout handling in the controller

### DIFF
--- a/internal/bft/mocks/request_timeout_handler.go
+++ b/internal/bft/mocks/request_timeout_handler.go
@@ -15,12 +15,12 @@ func (_m *RequestTimeoutHandler) OnAutoRemoveTimeout(requestInfo types.RequestIn
 	_m.Called(requestInfo)
 }
 
-// OnLeaderFwdRequestTimeout provides a mock function with given fields: request
-func (_m *RequestTimeoutHandler) OnLeaderFwdRequestTimeout(request []byte) {
-	_m.Called(request)
+// OnLeaderFwdRequestTimeout provides a mock function with given fields: request, requestInfo
+func (_m *RequestTimeoutHandler) OnLeaderFwdRequestTimeout(request []byte, requestInfo types.RequestInfo) {
+	_m.Called(request, requestInfo)
 }
 
-// OnRequestTimeout provides a mock function with given fields: request
-func (_m *RequestTimeoutHandler) OnRequestTimeout(request []byte) {
-	_m.Called(request)
+// OnRequestTimeout provides a mock function with given fields: request, requestInfo
+func (_m *RequestTimeoutHandler) OnRequestTimeout(request []byte, requestInfo types.RequestInfo) {
+	_m.Called(request, requestInfo)
 }

--- a/internal/bft/requestpool.go
+++ b/internal/bft/requestpool.go
@@ -28,13 +28,13 @@ const (
 // This interface is implemented by the bft.Controller.
 type RequestTimeoutHandler interface {
 
-	// OnRequestTimeout is called when a request timeout expires
-	OnRequestTimeout(request []byte)
+	// OnRequestTimeout is called when a request timeout expires.
+	OnRequestTimeout(request []byte, requestInfo types.RequestInfo)
 
-	// OnLeaderFwdRequestTimeout is called when a leader forwarding timeout expires
-	OnLeaderFwdRequestTimeout(request []byte)
+	// OnLeaderFwdRequestTimeout is called when a leader forwarding timeout expires.
+	OnLeaderFwdRequestTimeout(request []byte, requestInfo types.RequestInfo)
 
-	// OnAutoRemoveTimeout is called when a auto-remove timeout expires
+	// OnAutoRemoveTimeout is called when a auto-remove timeout expires.
 	OnAutoRemoveTimeout(requestInfo types.RequestInfo)
 }
 
@@ -215,7 +215,7 @@ func (rp *Pool) onRequestTO(request []byte, reqInfo types.RequestInfo) {
 	}
 	// may take time, in case Comm channel to leader is full; hence w/o the lock.
 	rp.logger.Debugf("Request %s timeout expired, going to send to leader", reqInfo)
-	rp.timeoutHandler.OnRequestTimeout(request)
+	rp.timeoutHandler.OnRequestTimeout(request, reqInfo)
 
 	rp.lock.Lock()
 	defer rp.lock.Unlock()
@@ -242,7 +242,7 @@ func (rp *Pool) onLeaderFwdRequestTO(request []byte, reqInfo types.RequestInfo) 
 	}
 	// may take time, in case Comm channel is full; hence w/o the lock.
 	rp.logger.Debugf("Request %s leader-forwarding timeout expired, going to complain on leader", reqInfo)
-	rp.timeoutHandler.OnLeaderFwdRequestTimeout(request)
+	rp.timeoutHandler.OnLeaderFwdRequestTimeout(request, reqInfo)
 
 	rp.lock.Lock()
 	defer rp.lock.Unlock()

--- a/internal/bft/requestpool_test.go
+++ b/internal/bft/requestpool_test.go
@@ -204,7 +204,6 @@ func TestReqPoolTimeout(t *testing.T) {
 	log := basicLog.Sugar()
 
 	byteReq1 := makeTestRequest("1", "1", "foo")
-
 	insp := &testRequestInspector{}
 
 	t.Run("request timeout", func(t *testing.T) {
@@ -212,11 +211,11 @@ func TestReqPoolTimeout(t *testing.T) {
 
 		toWG := &sync.WaitGroup{}
 		toWG.Add(1)
-		timeoutHandler.On("OnRequestTimeout", byteReq1).Run(func(args mock.Arguments) {
+		timeoutHandler.On("OnRequestTimeout", byteReq1, insp.RequestID(byteReq1)).Run(func(args mock.Arguments) {
 			toWG.Done()
 		}).Return()
 
-		timeoutHandler.On("OnLeaderFwdRequestTimeout", byteReq1).Run(func(args mock.Arguments) {
+		timeoutHandler.On("OnLeaderFwdRequestTimeout", byteReq1, insp.RequestID(byteReq1)).Run(func(args mock.Arguments) {
 			assert.Fail(t, "called OnLeaderFwdRequestTimeout")
 		}).Return()
 
@@ -254,13 +253,13 @@ func TestReqPoolTimeout(t *testing.T) {
 
 		to1WG := &sync.WaitGroup{}
 		to1WG.Add(1)
-		timeoutHandler.On("OnRequestTimeout", byteReq1).Run(func(args mock.Arguments) {
+		timeoutHandler.On("OnRequestTimeout", byteReq1, insp.RequestID(byteReq1)).Run(func(args mock.Arguments) {
 			to1WG.Done()
 		}).Return()
 
 		to2WG := &sync.WaitGroup{}
 		to2WG.Add(1)
-		timeoutHandler.On("OnLeaderFwdRequestTimeout", byteReq1).Run(func(args mock.Arguments) {
+		timeoutHandler.On("OnLeaderFwdRequestTimeout", byteReq1, insp.RequestID(byteReq1)).Run(func(args mock.Arguments) {
 			to2WG.Done()
 		}).Return()
 
@@ -298,13 +297,13 @@ func TestReqPoolTimeout(t *testing.T) {
 
 		to1WG := &sync.WaitGroup{}
 		to1WG.Add(1)
-		timeoutHandler.On("OnRequestTimeout", byteReq1).Run(func(args mock.Arguments) {
+		timeoutHandler.On("OnRequestTimeout", byteReq1, insp.RequestID(byteReq1)).Run(func(args mock.Arguments) {
 			to1WG.Done()
 		}).Return()
 
 		to2WG := &sync.WaitGroup{}
 		to2WG.Add(1)
-		timeoutHandler.On("OnLeaderFwdRequestTimeout", byteReq1).Run(func(args mock.Arguments) {
+		timeoutHandler.On("OnLeaderFwdRequestTimeout", byteReq1, insp.RequestID(byteReq1)).Run(func(args mock.Arguments) {
 			to2WG.Done()
 		}).Return()
 


### PR DESCRIPTION
- On request T/O: forward to leader
- On forwarding T/O: complain
- On optional auto-remove T/O: just report for now
- Make access to current view number thread safe

Signed-off-by: Yoav Tock <tock@il.ibm.com>