### PR TITLE
Consesus cleanup: synchronizer

### DIFF
--- a/pkg/consensus/consensus.go
+++ b/pkg/consensus/consensus.go
@@ -42,10 +42,6 @@ func (c *Consensus) Complain() {
 	panic("implement me")
 }
 
-func (c *Consensus) Sync() (protos.ViewMetadata, uint64) {
-	panic("implement me")
-}
-
 func (c *Consensus) Deliver(proposal types.Proposal, signatures []types.Signature) {
 	c.Application.Deliver(proposal, signatures)
 }
@@ -79,7 +75,7 @@ func (c *Consensus) Start() Future {
 		Assembler:        c.Assembler,
 		Application:      c,
 		FailureDetector:  c,
-		Synchronizer:     c,
+		Synchronizer:     c.Synchronizer,
 		Comm:             c.Comm,
 		Signer:           c.Signer,
 		RequestInspector: c.RequestInspector,


### PR DESCRIPTION
Pass the Synchronizer set in Consensus to the Controller.

Signed-off-by: Yoav Tock <tock@il.ibm.com>