### PR TITLE
Streamline Stop()

### DIFF
--- a/examples/naive_chain/chain_test.go
+++ b/examples/naive_chain/chain_test.go
@@ -88,6 +88,10 @@ func TestChain(t *testing.T) {
 			assert.Equal(t, []Transaction{{Id: fmt.Sprintf("tx%d", blockSeq), ClientID: "alice"}}, block.Transactions)
 		}
 	}
+
+	for _, chain := range chains {
+		chain.node.Stop()
+	}
 }
 
 func TestChainPartialSubmissions(t *testing.T) {

--- a/internal/bft/batcher.go
+++ b/internal/bft/batcher.go
@@ -64,7 +64,12 @@ func (b *Bundler) BatchRemainder(remainder [][]byte) {
 func (b *Bundler) Close() {
 	b.closeLock.Lock()
 	defer b.closeLock.Unlock()
-	close(b.CloseChan)
+	select {
+	case <-b.CloseChan:
+		return
+	default:
+		close(b.CloseChan)
+	}
 }
 
 // Reset resets the remainder and reopens the close channel to allow calling NextBatch

--- a/internal/bft/controller_test.go
+++ b/internal/bft/controller_test.go
@@ -46,13 +46,12 @@ func TestControllerBasic(t *testing.T) {
 		Comm:        comm,
 	}
 	configureProposerBuilder(controller)
-
-	end := controller.Start(1, 0)
+	err = controller.Start(1, 0)
+	assert.NoError(t, err)
 	controller.ViewChanged(2, 1)
 	controller.ViewChanged(3, 2)
 	controller.Stop()
 	controller.Stop()
-	end.Wait()
 }
 
 func TestQuorum(t *testing.T) {
@@ -103,10 +102,10 @@ func TestQuorum(t *testing.T) {
 			}
 			configureProposerBuilder(controller)
 
-			end := controller.Start(1, 0)
+			err = controller.Start(1, 0)
+			assert.NoError(t, err)
 			<-verifyLog
 			controller.Stop()
-			end.Wait()
 		})
 	}
 
@@ -139,11 +138,10 @@ func TestControllerLeaderBasic(t *testing.T) {
 		Comm:        commMock,
 	}
 	configureProposerBuilder(controller)
-
-	end := controller.Start(1, 0)
+	err = controller.Start(1, 0)
+	assert.NoError(t, err)
 	<-batcherChan
 	controller.Stop()
-	end.Wait()
 	batcher.AssertCalled(t, "NextBatch")
 }
 
@@ -207,7 +205,8 @@ func TestLeaderPropose(t *testing.T) {
 	configureProposerBuilder(controller)
 
 	commWG.Add(2)
-	end := controller.Start(1, 0)
+	err = controller.Start(1, 0)
+	assert.NoError(t, err)
 	commWG.Wait() // propose
 
 	commWG.Add(1)
@@ -226,7 +225,6 @@ func TestLeaderPropose(t *testing.T) {
 	commWG.Wait()
 
 	controller.Stop()
-	end.Wait()
 	app.AssertNumberOfCalls(t, "Deliver", 1)
 }
 
@@ -284,7 +282,8 @@ func TestLeaderChange(t *testing.T) {
 	}
 	configureProposerBuilder(controller)
 
-	end := controller.Start(1, 0)
+	err = controller.Start(1, 0)
+	assert.NoError(t, err)
 
 	prePrepareWrongView := proto.Clone(prePrepare).(*protos.Message)
 	prePrepareWrongViewGet := prePrepareWrongView.GetPrePrepare()
@@ -306,7 +305,6 @@ func TestLeaderChange(t *testing.T) {
 	assembler.AssertNumberOfCalls(t, "AssembleProposal", 1)
 	comm.AssertNumberOfCalls(t, "BroadcastConsensus", 2)
 	controller.Stop()
-	end.Wait()
 }
 
 func createView(c *bft.Controller, leader, proposalSequence, viewNum uint64, quorumSize int) *bft.View {


### PR DESCRIPTION
Make Controller.Stop() and View.Abort() wait for internal
go-routines to finish.

Introduce Consensus.Stop()

Signed-off-by: Yoav Tock <tock@il.ibm.com>