### PR TITLE
Make WAL Create to return ErrWALAlreadyExists

### DIFF
--- a/pkg/wal/writeaheadlog_test.go
+++ b/pkg/wal/writeaheadlog_test.go
@@ -12,7 +12,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/SmartBFT-Go/consensus/pkg/api"
@@ -86,9 +85,7 @@ func TestWriteAheadLogFile_Create(t *testing.T) {
 
 		wal, err := Create(logger, dirPath, nil)
 		assert.Error(t, err)
-		if err != nil {
-			assert.True(t, strings.HasPrefix(err.Error(), "wal: directory not empty:"))
-		}
+		assert.Equal(t, err, ErrWALAlreadyExists)
 		assert.Nil(t, wal)
 	})
 }


### PR DESCRIPTION
In case WAL has already exists while trying to call Create this commit
makes Create API to return ErrWALAlreadyExists as an indication.

Signed-off-by: Artem Barger <bartem@il.ibm.com>