### PR TITLE
Hearbeats to use logical clock

### DIFF
--- a/internal/bft/controller_test.go
+++ b/internal/bft/controller_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-
 	"time"
 
 	"github.com/SmartBFT-Go/consensus/internal/bft"
@@ -37,7 +36,7 @@ func TestControllerBasic(t *testing.T) {
 	pool := &mocks.RequestPool{}
 	pool.On("Close")
 	leaderMon := &mocks.LeaderMonitor{}
-	leaderMon.On("StartFollower", mock.Anything, mock.Anything)
+	leaderMon.On("ChangeRole", mock.Anything, mock.Anything, mock.Anything)
 	leaderMon.On("Close")
 
 	comm := &mocks.CommMock{}
@@ -57,7 +56,7 @@ func TestControllerBasic(t *testing.T) {
 
 	controller.Start(1, 0)
 
-	leaderMon.On("ProcessMsg", uint64(1), heartbeat.GetHeartBeat())
+	leaderMon.On("ProcessMsg", uint64(1), heartbeat)
 	controller.ProcessMessages(1, heartbeat)
 	controller.ViewChanged(2, 1)
 	controller.ViewChanged(3, 2)
@@ -98,7 +97,7 @@ func TestQuorum(t *testing.T) {
 			pool := &mocks.RequestPool{}
 			pool.On("Close")
 			leaderMon := &mocks.LeaderMonitor{}
-			leaderMon.On("StartFollower", mock.Anything, mock.Anything)
+			leaderMon.On("ChangeRole", bft.Follower, mock.Anything, mock.Anything)
 			leaderMon.On("Close")
 			commMock := &mocks.CommMock{}
 			var nodes []uint64
@@ -141,7 +140,7 @@ func TestControllerLeaderBasic(t *testing.T) {
 	pool := &mocks.RequestPool{}
 	pool.On("Close")
 	leaderMon := &mocks.LeaderMonitor{}
-	leaderMon.On("StartLeader", mock.Anything, mock.Anything)
+	leaderMon.On("ChangeRole", bft.Leader, mock.Anything, mock.Anything)
 	leaderMon.On("Close")
 	commMock := &mocks.CommMock{}
 	commMock.On("Nodes").Return([]uint64{0, 1, 2, 3})
@@ -209,7 +208,7 @@ func TestLeaderPropose(t *testing.T) {
 	reqPool.On("Prune", mock.Anything)
 	reqPool.On("Close")
 	leaderMon := &mocks.LeaderMonitor{}
-	leaderMon.On("StartLeader", mock.Anything, mock.Anything)
+	leaderMon.On("ChangeRole", bft.Leader, mock.Anything, mock.Anything)
 	leaderMon.On("Close")
 
 	controller := &bft.Controller{
@@ -311,8 +310,8 @@ func TestLeaderChange(t *testing.T) {
 	reqPool := &mocks.RequestPool{}
 	reqPool.On("Close")
 	leaderMon := &mocks.LeaderMonitor{}
-	leaderMon.On("StartFollower", mock.Anything, mock.Anything)
-	leaderMon.On("StartLeader", mock.Anything, mock.Anything)
+	leaderMon.On("ChangeRole", bft.Follower, mock.Anything, mock.Anything)
+	leaderMon.On("ChangeRole", bft.Leader, mock.Anything, mock.Anything)
 	leaderMon.On("Close")
 
 	signer := &mocks.SignerMock{}
@@ -405,8 +404,8 @@ func TestControllerLeaderRequestHandling(t *testing.T) {
 			pool := &mocks.RequestPool{}
 			pool.On("Close")
 			leaderMon := &mocks.LeaderMonitor{}
-			leaderMon.On("StartFollower", mock.Anything, mock.Anything)
-			leaderMon.On("StartLeader", mock.Anything, mock.Anything)
+			leaderMon.On("ChangeRole", bft.Follower, mock.Anything, mock.Anything)
+			leaderMon.On("ChangeRole", bft.Leader, mock.Anything, mock.Anything)
 			leaderMon.On("Close")
 			if testCase.shouldEnqueue {
 				submittedToPool.Add(1)

--- a/internal/bft/heartbeatmonitor.go
+++ b/internal/bft/heartbeatmonitor.go
@@ -14,7 +14,10 @@ import (
 )
 
 const (
-	DefaultHeartbeatTimeout = 60 * time.Second
+	DefaultHeartbeatTimeout      = 60 * time.Second
+	HeartbeatFrequency           = 10 // How much heart beats per timeout
+	Leader                  Role = false
+	Follower                Role = true
 )
 
 //go:generate mockery -dir . -name HeartbeatTimeoutHandler -case underscore -output ./mocks/
@@ -24,172 +27,196 @@ type HeartbeatTimeoutHandler interface {
 	OnHeartbeatTimeout(view uint64, leaderID uint64)
 }
 
+type Role bool
+
+type roleChange struct {
+	view     uint64
+	leaderID uint64
+	follower Role
+}
+
 type HeartbeatMonitor struct {
-	logger          api.Logger
-	hbTimeout       time.Duration
-	hbInterval      time.Duration
-	comm            Comm
-	handler         HeartbeatTimeoutHandler
-	mutex           sync.Mutex
-	timer           *time.Timer
-	view            uint64
-	leaderID        uint64
-	follower        bool
-	lastInHeartbeat time.Time
+	scheduler     <-chan time.Time
+	inc           chan incMsg
+	stopChan      chan struct{}
+	commandChan   chan roleChange
+	logger        api.Logger
+	hbTimeout     time.Duration
+	comm          Comm
+	handler       HeartbeatTimeoutHandler
+	view          uint64
+	leaderID      uint64
+	follower      Role
+	lastHeartbeat time.Time
+	lastTick      time.Time
+	running       sync.WaitGroup
+	runOnce       sync.Once
+	timedOut      bool
 }
 
 func NewHeartbeatMonitor(
+	scheduler <-chan time.Time,
 	logger api.Logger,
 	heartbeatTimeout time.Duration,
 	comm Comm,
 	handler HeartbeatTimeoutHandler,
 ) *HeartbeatMonitor {
-	if heartbeatTimeout/10 < time.Nanosecond {
-		return nil
-	}
-
 	hm := &HeartbeatMonitor{
-		logger:     logger,
-		hbTimeout:  heartbeatTimeout,
-		hbInterval: heartbeatTimeout / 10,
-		comm:       comm,
-		handler:    handler,
+		stopChan:    make(chan struct{}),
+		inc:         make(chan incMsg),
+		commandChan: make(chan roleChange),
+		scheduler:   scheduler,
+		logger:      logger,
+		hbTimeout:   heartbeatTimeout,
+		comm:        comm,
+		handler:     handler,
 	}
 	return hm
 }
 
-// StartFollower will start following the heartbeats of the leader of the view.
-func (hm *HeartbeatMonitor) StartFollower(view uint64, leaderID uint64) {
-	hm.logger.Debugf("Starting heartbeat timeout on follower, duration: %s; leader: %d, view: %d",
-		hm.hbTimeout.String(), leaderID, view)
-
-	hm.mutex.Lock()
-	defer hm.mutex.Unlock()
-
-	if hm.timer != nil {
-		hm.timer.Stop()
-	}
-	hm.view = view
-	hm.leaderID = leaderID
-	hm.follower = true
-	hm.lastInHeartbeat = time.Now()
-
-	hm.timer = time.AfterFunc(hm.hbTimeout, func() { hm.onHeartbeatTimeout(view, leaderID) })
-}
-
-func (hm *HeartbeatMonitor) onHeartbeatTimeout(view uint64, leaderID uint64) {
-	// TODO Optimisation: check for extension due to data messages from leader (backlog)
-	hm.logger.Debugf("Heartbeat timer event, checking expiration")
-	expired := hm.checkExpiration()
-	if expired {
-		hm.handler.OnHeartbeatTimeout(view, leaderID)
-	}
-}
-
-func (hm *HeartbeatMonitor) checkExpiration() bool {
-	hm.mutex.Lock()
-	defer hm.mutex.Unlock()
-
-	delta := time.Since(hm.lastInHeartbeat)
-	if delta >= hm.hbTimeout {
-		hm.logger.Debugf("Heartbeat timeout expired; last HB: %s, delta: %s", hm.lastInHeartbeat, delta)
-		return true
-	}
-
-	extension := hm.hbTimeout - delta
-	hm.timer.Reset(extension)
-	hm.logger.Debugf("Heartbeat timeout extended; duration: %s", extension)
-	return false
-}
-
-// ProcessMsg handles an incoming heartbeat.
-// If the sender and msg.View equal what we expect, and the timeout had not expired yet, the timeout is extended.
-func (hm *HeartbeatMonitor) ProcessMsg(sender uint64, msg *smartbftprotos.HeartBeat) {
-	hm.mutex.Lock()
-	defer hm.mutex.Unlock()
-
-	if !hm.follower {
-		hm.logger.Debugf("Heartbeat monitor is not a follower, ignoring; sender: %d, msg: %v", sender, msg)
-		return
-	}
-
-	if sender != hm.leaderID {
-		hm.logger.Debugf("Heartbeat sender is not the leader, ignoring; leader: %d, sender: %d, msg: %v", hm.leaderID, sender, msg)
-		return
-	}
-
-	if msg.View != hm.view {
-		hm.logger.Debugf("Heartbeat view is different than monitor view, ignoring; view: %d, sender: %d, msg: %v", hm.leaderID, sender, msg)
-		return
-	}
-
-	hm.lastInHeartbeat = time.Now()
-	hm.logger.Debugf("Heartbeat arrival time recorded, timeout will be extended; msg: %v", msg)
-}
-
-// StartLeader will start sending heartbeats to all followers.
-func (hm *HeartbeatMonitor) StartLeader(view uint64, leaderID uint64) {
-	hm.logger.Debugf("Starting heartbeat transmission, interval: %s; leader: %d, view: %d",
-		hm.hbInterval, leaderID, view)
-
-	hm.mutex.Lock()
-	defer hm.mutex.Unlock()
-
-	if hm.timer != nil {
-		hm.timer.Stop()
-	}
-	hm.view = view
-	hm.leaderID = leaderID
-	hm.follower = false
-	hm.timer = time.AfterFunc(hm.hbInterval, hm.sendHeartbeat)
-}
-
-func (hm *HeartbeatMonitor) sendHeartbeat() {
-	// TODO Optimisation: check for extension due to data messages sent by leader (backlog)
-
-	view, follower, heartbeat, doSend := hm.prepareSend()
-	if !doSend {
-		return
-	}
-
-	hm.comm.BroadcastConsensus(heartbeat)
-
-	hm.mutex.Lock()
-	defer hm.mutex.Unlock()
-
-	if view == hm.view && follower == hm.follower {
-		hm.timer.Reset(hm.hbInterval)
-	}
-}
-
-func (hm *HeartbeatMonitor) prepareSend() (view uint64, follower bool, heartbeat *smartbftprotos.Message, doSend bool) {
-	hm.mutex.Lock()
-	defer hm.mutex.Unlock()
-
-	view = hm.view
-	follower = hm.follower
-	if follower {
-		return view, follower, nil, false
-	}
-
-	heartbeat = &smartbftprotos.Message{
-		Content: &smartbftprotos.Message_HeartBeat{
-			HeartBeat: &smartbftprotos.HeartBeat{
-				View: view,
-			},
-		},
-	}
-	doSend = true
-	return
+func (hm *HeartbeatMonitor) start() {
+	hm.running.Add(1)
+	go hm.run()
 }
 
 // Close stops following or sending heartbeats.
 func (hm *HeartbeatMonitor) Close() {
-	hm.mutex.Lock()
-	defer hm.mutex.Unlock()
-
-	if hm.timer != nil {
-		hm.timer.Stop()
+	if hm.closed() {
+		return
 	}
-	hm.view = 0
+
+	defer hm.running.Wait()
+	close(hm.stopChan)
+}
+
+func (hm *HeartbeatMonitor) run() {
+	defer hm.running.Done()
+	for {
+		select {
+		case <-hm.stopChan:
+			return
+		case now := <-hm.scheduler:
+			hm.tick(now)
+		case msg := <-hm.inc:
+			hm.handleMsg(msg.sender, msg.Message)
+		case cmd := <-hm.commandChan:
+			hm.handleCommand(cmd)
+		}
+	}
+}
+
+// ProcessMsg handles an incoming heartbeat.
+// If the sender and msg.View equal what we expect, and the timeout had not expired yet, the timeout is extended.
+func (hm *HeartbeatMonitor) ProcessMsg(sender uint64, msg *smartbftprotos.Message) {
+	hm.inc <- incMsg{
+		sender:  sender,
+		Message: msg,
+	}
+}
+
+// ChangeRole will change the role of this HeartbeatMonitor
+func (hm *HeartbeatMonitor) ChangeRole(follower Role, view uint64, leaderID uint64) {
+	hm.runOnce.Do(func() {
+		hm.follower = follower
+		hm.start()
+	})
+
+	role := "leader"
+	if follower {
+		role = "follower"
+	}
+
+	hm.logger.Infof("Changing to %s role, current view: %d, current leader: %d", role, view, leaderID)
+	hm.commandChan <- roleChange{
+		leaderID: leaderID,
+		view:     view,
+		follower: follower,
+	}
+}
+
+func (hm *HeartbeatMonitor) handleMsg(sender uint64, msg *smartbftprotos.Message) {
+	if !hm.follower {
+		hm.logger.Infof("Heartbeat monitor is not a follower, ignoring; sender: %d, msg: %v", sender, msg)
+		return
+	}
+
+	if sender != hm.leaderID {
+		hm.logger.Infof("Heartbeat from %d which is not the leader %d", sender, hm.leaderID)
+		return
+	}
+
+	hbMsg := msg.GetHeartBeat()
+	// TODO Optimisation: check for extension due to data messages sent by leader (backlog)
+	if hbMsg == nil {
+		return
+	}
+
+	if hbMsg.View != hm.view {
+		hm.logger.Infof("Heartbeat view is different than monitor view, ignoring; view: %d, sender: %d, msg: %v", hm.leaderID, sender, msg)
+		return
+	}
+
+	hm.logger.Debugf("Received heartbeat from %d, last heartbeat was %v ago", sender, hm.lastTick.Sub(hm.lastHeartbeat))
+	hm.lastHeartbeat = hm.lastTick
+}
+
+func (hm *HeartbeatMonitor) tick(now time.Time) {
+	hm.lastTick = now
+	if hm.follower {
+		hm.followerTick(now)
+	} else {
+		hm.leaderTick(now)
+	}
+}
+
+func (hm *HeartbeatMonitor) closed() bool {
+	select {
+	case <-hm.stopChan:
+		return true
+	default:
+		return false
+	}
+}
+
+func (hm *HeartbeatMonitor) handleCommand(cmd roleChange) {
+	hm.timedOut = false
+	hm.view = cmd.view
+	hm.leaderID = cmd.leaderID
+	hm.follower = cmd.follower
+	hm.lastHeartbeat = hm.lastTick
+}
+
+func (hm *HeartbeatMonitor) leaderTick(now time.Time) {
+	if now.Sub(hm.lastHeartbeat)*HeartbeatFrequency < hm.hbTimeout {
+		return
+	}
+
+	hm.logger.Debugf("Sending heartbeat with view %d", hm.view)
+	heartbeat := &smartbftprotos.Message{
+		Content: &smartbftprotos.Message_HeartBeat{
+			HeartBeat: &smartbftprotos.HeartBeat{
+				View: hm.view,
+			},
+		},
+	}
+	hm.comm.BroadcastConsensus(heartbeat)
+	hm.lastHeartbeat = now
+}
+
+func (hm *HeartbeatMonitor) followerTick(now time.Time) {
+	if hm.timedOut || hm.lastHeartbeat.IsZero() {
+		hm.lastHeartbeat = now
+		return
+	}
+
+	delta := now.Sub(hm.lastHeartbeat)
+	if delta >= hm.hbTimeout {
+		hm.logger.Warnf("Heartbeat timeout (%v) from %d expired; last heartbeat was observed %s ago",
+			hm.hbTimeout, hm.leaderID, delta)
+		hm.handler.OnHeartbeatTimeout(hm.view, hm.leaderID)
+		hm.timedOut = true
+		return
+	}
+
+	hm.logger.Debugf("Last heartbeat was %v ago", delta)
 }

--- a/internal/bft/heartbeatmonitor_test.go
+++ b/internal/bft/heartbeatmonitor_test.go
@@ -22,7 +22,7 @@ var (
 	heartbeat = &smartbftprotos.Message{
 		Content: &smartbftprotos.Message_HeartBeat{
 			HeartBeat: &smartbftprotos.HeartBeat{
-				View: 1,
+				View: 10,
 			},
 		},
 	}
@@ -36,212 +36,161 @@ func TestHeartbeatMonitor_New(t *testing.T) {
 	comm := &mocks.CommMock{}
 	handler := &mocks.HeartbeatTimeoutHandler{}
 
-	hm := bft.NewHeartbeatMonitor(log, time.Hour, comm, handler)
+	scheduler := make(chan time.Time)
+	hm := bft.NewHeartbeatMonitor(scheduler, log, bft.DefaultHeartbeatTimeout, comm, handler)
 	assert.NotNil(t, hm)
 	hm.Close()
 }
 
-func TestHeartbeatMonitor_StartLeader(t *testing.T) {
+func TestHeartbeatMonitorLeader(t *testing.T) {
 	basicLog, err := zap.NewDevelopment()
 	assert.NoError(t, err)
 	log := basicLog.Sugar()
+
 	comm := &mocks.CommMock{}
 	handler := &mocks.HeartbeatTimeoutHandler{}
-	hm := bft.NewHeartbeatMonitor(log, time.Millisecond, comm, handler)
+	scheduler := make(chan time.Time)
 
-	var countMutex sync.Mutex
-	count1 := 10
-	count2 := 10
-	toWG1 := &sync.WaitGroup{}
-	toWG1.Add(1)
-	toWG2 := &sync.WaitGroup{}
-	toWG2.Add(1)
+	hm := bft.NewHeartbeatMonitor(scheduler, log, bft.DefaultHeartbeatTimeout, comm, handler)
+
+	var toWG1 sync.WaitGroup
+	toWG1.Add(10)
+	var toWG2 sync.WaitGroup
+	toWG2.Add(10)
 	comm.On("BroadcastConsensus", mock.AnythingOfType("*smartbftprotos.Message")).Run(func(args mock.Arguments) {
 		msg := args[0].(*smartbftprotos.Message)
 		view := msg.GetHeartBeat().View
-		countMutex.Lock()
-		defer countMutex.Unlock()
 
 		if uint64(10) == view {
-			count1--
-			if count1 == 0 {
-				toWG1.Done()
-			}
+			toWG1.Done()
 		} else if uint64(20) == view {
-			count2--
-			if count2 == 0 {
-				toWG2.Done()
-			}
+			toWG2.Done()
 		}
-		log.Debugf("On: view: %d", view)
 	}).Return()
 
-	hm.StartLeader(10, 12)
+	clock := fakeTime{}
+	hm.ChangeRole(bft.Leader, 10, 12)
+	clock.advanceTime(10, scheduler)
 	toWG1.Wait()
-	hm.StartLeader(20, 12)
+
+	hm.ChangeRole(bft.Leader, 20, 12)
+	clock.advanceTime(10, scheduler)
 	toWG2.Wait()
+
 	hm.Close()
 }
 
-func TestHeartbeatMonitor_Follower(t *testing.T) {
-	basicLog, err := zap.NewDevelopment()
-	assert.NoError(t, err)
-	log := basicLog.Sugar()
+func TestHeartbeatMonitorFollower(t *testing.T) {
+	noop := func(_ *bft.HeartbeatMonitor) {}
 
-	t.Run("timeout expires", func(t *testing.T) {
-		comm := &mocks.CommMock{}
-		handler := &mocks.HeartbeatTimeoutHandler{}
+	for _, testCase := range []struct {
+		description                 string
+		onHeartbeatTimeoutCallCount int
+		heartbeatMessage            *smartbftprotos.Message
+		event                       func(*bft.HeartbeatMonitor)
+		sender                      uint64
+	}{
+		{
+			description:                 "timeout expires",
+			sender:                      12,
+			heartbeatMessage:            &smartbftprotos.Message{},
+			onHeartbeatTimeoutCallCount: 1,
+			event:                       noop,
+		},
+		{
+			description:      "heartbeats prevent timeout",
+			sender:           12,
+			heartbeatMessage: heartbeat,
+			event:            noop,
+		},
+		{
+			description:                 "bad heartbeats do not prevent timeout",
+			sender:                      12,
+			heartbeatMessage:            prePrepare,
+			onHeartbeatTimeoutCallCount: 1,
+			event:                       noop,
+		},
+		{
+			description:                 "heartbeats not from the leader do not prevent timeout",
+			sender:                      13,
+			heartbeatMessage:            heartbeat,
+			onHeartbeatTimeoutCallCount: 1,
+			event:                       noop,
+		},
+		{
+			description:                 "view change to dead leader",
+			sender:                      12,
+			onHeartbeatTimeoutCallCount: 1,
+			event: func(hm *bft.HeartbeatMonitor) {
+				hm.ChangeRole(bft.Follower, 11, 12)
+			},
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+			basicLog, err := zap.NewDevelopment()
+			assert.NoError(t, err)
+			log := basicLog.Sugar()
 
-		hm := bft.NewHeartbeatMonitor(log, 10*time.Millisecond, comm, handler)
+			scheduler := make(chan time.Time)
+			incrementUnit := bft.DefaultHeartbeatTimeout / bft.HeartbeatFrequency
 
-		toWG := &sync.WaitGroup{}
-		toWG.Add(1)
-		handler.On("OnHeartbeatTimeout", uint64(10), uint64(12)).Run(func(args mock.Arguments) {
-			toWG.Done()
-		}).Return()
+			comm := &mocks.CommMock{}
+			handler := &mocks.HeartbeatTimeoutHandler{}
+			handler.On("OnHeartbeatTimeout", uint64(10), uint64(12))
+			handler.On("OnHeartbeatTimeout", uint64(11), uint64(12))
 
-		hm.StartFollower(10, 12)
-		toWG.Wait()
+			hm := bft.NewHeartbeatMonitor(scheduler, log, bft.DefaultHeartbeatTimeout, comm, handler)
 
-		hm.Close()
-	})
+			hm.ChangeRole(bft.Follower, 10, 12)
 
-	t.Run("heartbeats prevent timeout", func(t *testing.T) {
-		comm := &mocks.CommMock{}
-		handler := &mocks.HeartbeatTimeoutHandler{}
+			start := time.Now()
+			scheduler <- start
+			hm.ProcessMsg(12, heartbeat)
+			testCase.event(hm)
 
-		hbTO := time.Second
-		hm := bft.NewHeartbeatMonitor(log, hbTO, comm, handler)
+			start = start.Add(incrementUnit).Add(time.Second)
 
-		handler.On("OnHeartbeatTimeout", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-			t.Fail()
-		}).Return()
-
-		done := make(chan bool)
-		go func() {
-			for i := 0; i < 30; i++ {
-				hb := heartbeat.GetHeartBeat()
-				hb.View = 10
-				hm.ProcessMsg(12, hb)
-				time.Sleep(hbTO / 10)
+			for i := time.Duration(1); i <= bft.HeartbeatFrequency*2; i++ {
+				elapsed := start.Add(incrementUnit*i + time.Millisecond)
+				scheduler <- elapsed
+				hm.ProcessMsg(testCase.sender, testCase.heartbeatMessage)
 			}
-			close(done)
-		}()
+			hm.Close()
 
-		hm.StartFollower(10, 12)
-		<-done
-		hm.Close()
-	})
-
-	t.Run("close prevents timeout", func(t *testing.T) {
-		comm := &mocks.CommMock{}
-		handler := &mocks.HeartbeatTimeoutHandler{}
-
-		hbTO := 500 * time.Millisecond
-		hm := bft.NewHeartbeatMonitor(log, hbTO, comm, handler)
-
-		handler.On("OnHeartbeatTimeout", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-			t.Fail()
-		}).Return()
-
-		hm.StartFollower(10, 12)
-		hm.Close()
-		time.Sleep(hbTO * 2)
-	})
-
-	t.Run("bad heartbeats do not prevent timeout", func(t *testing.T) {
-		comm := &mocks.CommMock{}
-		handler := &mocks.HeartbeatTimeoutHandler{}
-
-		hbTO := time.Second
-		hm := bft.NewHeartbeatMonitor(log, hbTO, comm, handler)
-
-		toWG := &sync.WaitGroup{}
-		toWG.Add(1)
-		handler.On("OnHeartbeatTimeout", uint64(10), uint64(12)).Run(func(args mock.Arguments) {
-			toWG.Done()
-		}).Return()
-
-		done := make(chan bool)
-		go func() {
-			for i := 0; i < 20; i++ {
-				time.Sleep(hbTO / 10)
-				// either 9,12 or 10,13, both are wrong.
-				hb := heartbeat.GetHeartBeat()
-				hb.View = uint64(9 + i%2)
-				hm.ProcessMsg(uint64(12+i%2), hb)
-			}
-			close(done)
-		}()
-
-		hm.StartFollower(10, 12)
-		<-done
-		toWG.Wait()
-
-		hm.Close()
-	})
-
-	t.Run("follow new view", func(t *testing.T) {
-		comm := &mocks.CommMock{}
-		handler := &mocks.HeartbeatTimeoutHandler{}
-
-		hbTO := time.Second
-		hm := bft.NewHeartbeatMonitor(log, hbTO, comm, handler)
-
-		toWG := &sync.WaitGroup{}
-		toWG.Add(1)
-		handler.On("OnHeartbeatTimeout", uint64(11), uint64(13)).Run(func(args mock.Arguments) {
-			toWG.Done()
-		}).Return()
-
-		done := make(chan bool)
-		go func() {
-			for i := 0; i < 20; i++ {
-				time.Sleep(hbTO / 10)
-				hb := heartbeat.GetHeartBeat()
-				hb.View = uint64(10)
-				hm.ProcessMsg(uint64(12), hb)
-			}
-			close(done)
-		}()
-
-		hm.StartFollower(10, 12)
-		time.Sleep(hbTO / 5)
-		hm.StartFollower(11, 13)
-		<-done
-		toWG.Wait()
-
-		hm.Close()
-	})
+			handler.AssertNumberOfCalls(t, "OnHeartbeatTimeout", testCase.onHeartbeatTimeoutCallCount)
+		})
+	}
 }
 
-func TestHeartbeatMonitor_LeaderAndFollower(t *testing.T) {
+func TestHeartbeatMonitorLeaderAndFollower(t *testing.T) {
 	basicLog, err := zap.NewDevelopment()
 	assert.NoError(t, err)
 	log := basicLog.Sugar()
-	hbTO := time.Second
+
+	scheduler1 := make(chan time.Time)
+	scheduler2 := make(chan time.Time)
 
 	comm1 := &mocks.CommMock{}
 	handler1 := &mocks.HeartbeatTimeoutHandler{}
-	hm1 := bft.NewHeartbeatMonitor(log, hbTO, comm1, handler1)
+	hm1 := bft.NewHeartbeatMonitor(scheduler1, log, bft.DefaultHeartbeatTimeout, comm1, handler1)
 
 	comm2 := &mocks.CommMock{}
 	handler2 := &mocks.HeartbeatTimeoutHandler{}
-	hm2 := bft.NewHeartbeatMonitor(log, hbTO, comm2, handler2)
+	hm2 := bft.NewHeartbeatMonitor(scheduler2, log, bft.DefaultHeartbeatTimeout, comm2, handler2)
 
 	comm1.On("BroadcastConsensus", mock.AnythingOfType("*smartbftprotos.Message")).Run(func(args mock.Arguments) {
 		msg := args[0].(*smartbftprotos.Message)
-		go func() { hm2.ProcessMsg(1, msg.GetHeartBeat()) }()
-	}).Return()
+		hm2.ProcessMsg(1, msg)
+	})
 
 	comm2.On("BroadcastConsensus", mock.AnythingOfType("*smartbftprotos.Message")).Run(func(args mock.Arguments) {
 		msg := args[0].(*smartbftprotos.Message)
-		go func() { hm1.ProcessMsg(2, msg.GetHeartBeat()) }()
-	}).Return()
+		hm1.ProcessMsg(2, msg)
+	})
 
 	toWG := &sync.WaitGroup{}
 	toWG.Add(1)
-	handler1.On("OnHeartbeatTimeout", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+	handler1.On("OnHeartbeatTimeout", uint64(12), uint64(2)).Run(func(args mock.Arguments) {
 		view := args[0].(uint64)
 		if view != 12 {
 			t.Fail()
@@ -249,22 +198,38 @@ func TestHeartbeatMonitor_LeaderAndFollower(t *testing.T) {
 			toWG.Done()
 		}
 	}).Return()
-	handler2.On("OnHeartbeatTimeout", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-		t.Fail()
-	}).Return()
 
-	hm1.StartLeader(10, 1)
-	hm2.StartFollower(10, 1)
-	time.Sleep(2 * hbTO)
+	clock := fakeTime{}
 
-	hm1.StartFollower(11, 2)
-	hm2.StartLeader(11, 2)
-	time.Sleep(2 * hbTO)
+	hm1.ChangeRole(bft.Leader, 10, 1)
+	hm2.ChangeRole(bft.Follower, 10, 1)
+	clock.advanceTime(bft.HeartbeatFrequency*2, scheduler1, scheduler2)
 
-	hm1.StartFollower(12, 2)
-	hm2.StartLeader(12, 2)
-	time.Sleep(hbTO / 5)
+	hm1.ChangeRole(bft.Follower, 11, 2)
+	hm2.ChangeRole(bft.Leader, 11, 2)
+	clock.advanceTime(bft.HeartbeatFrequency*2, scheduler1, scheduler2)
+
+	hm1.ChangeRole(bft.Follower, 12, 2)
+	hm2.ChangeRole(bft.Leader, 12, 2)
 	hm2.Close()
-	toWG.Wait()
+	clock.advanceTime(bft.HeartbeatFrequency*2, scheduler1)
 	hm1.Close()
+
+	handler1.AssertCalled(t, "OnHeartbeatTimeout", uint64(12), uint64(2))
+	handler1.AssertNumberOfCalls(t, "OnHeartbeatTimeout", 1)
+}
+
+type fakeTime struct {
+	time time.Time
+}
+
+func (t *fakeTime) advanceTime(ticks time.Duration, schedulers ...chan time.Time) {
+	for i := time.Duration(1); i <= ticks; i++ {
+		incrementUnit := bft.DefaultHeartbeatTimeout / bft.HeartbeatFrequency
+		newTime := t.time.Add(incrementUnit)
+		for _, scheduler := range schedulers {
+			scheduler <- newTime
+		}
+		t.time = newTime
+	}
 }

--- a/internal/bft/mocks/leader_monitor.go
+++ b/internal/bft/mocks/leader_monitor.go
@@ -2,6 +2,7 @@
 
 package mocks
 
+import bft "github.com/SmartBFT-Go/consensus/internal/bft"
 import mock "github.com/stretchr/testify/mock"
 import smartbftprotos "github.com/SmartBFT-Go/consensus/smartbftprotos"
 
@@ -10,22 +11,17 @@ type LeaderMonitor struct {
 	mock.Mock
 }
 
+// ChangeRole provides a mock function with given fields: role, view, leaderID
+func (_m *LeaderMonitor) ChangeRole(role bft.Role, view uint64, leaderID uint64) {
+	_m.Called(role, view, leaderID)
+}
+
 // Close provides a mock function with given fields:
 func (_m *LeaderMonitor) Close() {
 	_m.Called()
 }
 
 // ProcessMsg provides a mock function with given fields: sender, msg
-func (_m *LeaderMonitor) ProcessMsg(sender uint64, msg *smartbftprotos.HeartBeat) {
+func (_m *LeaderMonitor) ProcessMsg(sender uint64, msg *smartbftprotos.Message) {
 	_m.Called(sender, msg)
-}
-
-// StartFollower provides a mock function with given fields: view, leaderID
-func (_m *LeaderMonitor) StartFollower(view uint64, leaderID uint64) {
-	_m.Called(view, leaderID)
-}
-
-// StartLeader provides a mock function with given fields: view, leaderID
-func (_m *LeaderMonitor) StartLeader(view uint64, leaderID uint64) {
-	_m.Called(view, leaderID)
 }

--- a/pkg/consensus/consensus.go
+++ b/pkg/consensus/consensus.go
@@ -39,6 +39,7 @@ type Consensus struct {
 	Metadata          protos.ViewMetadata
 	LastProposal      types.Proposal
 	LastSignatures    []types.Signature
+	Scheduler         <-chan time.Time
 
 	controller *algorithm.Controller
 	state      *algorithm.PersistedState
@@ -95,7 +96,7 @@ func (c *Consensus) Start() {
 
 	pool := algorithm.NewPool(c.Logger, c.RequestInspector, c.controller, opts)
 	batchBuilder := algorithm.NewBatchBuilder(pool, c.BatchSize, c.BatchTimeout)
-	leaderMonitor := algorithm.NewHeartbeatMonitor(c.Logger, algorithm.DefaultHeartbeatTimeout, c, c.controller)
+	leaderMonitor := algorithm.NewHeartbeatMonitor(c.Scheduler, c.Logger, algorithm.DefaultHeartbeatTimeout, c, c.controller)
 	c.controller.RequestPool = pool
 	c.controller.Batcher = batchBuilder
 	c.controller.LeaderMonitor = leaderMonitor

--- a/test/test_app.go
+++ b/test/test_app.go
@@ -26,6 +26,7 @@ type App struct {
 	Node      *Node
 	logLevel  zap.AtomicLevel
 	latestMD  *smartbftprotos.ViewMetadata
+	clock     *time.Ticker
 }
 
 func (a *App) Mute() {
@@ -171,6 +172,7 @@ func newNode(id uint64, network Network) *App {
 	logger, _ := logConfig.Build()
 
 	app := &App{
+		clock:     time.NewTicker(time.Second),
 		ID:        id,
 		Delivered: make(chan *AppRecord, 100),
 		logLevel:  logConfig.Level,
@@ -181,6 +183,7 @@ func newNode(id uint64, network Network) *App {
 
 	app.Setup = func() {
 		c := &consensus.Consensus{
+			Scheduler:         app.clock.C,
 			SelfID:            id,
 			Logger:            logger.Sugar(),
 			WAL:               wal,


### PR DESCRIPTION
This commit makes the heart beat monitor use logical time
instead of real time.

It reduces the time to run the heart beat tests from 15s to 0

Signed-off-by: yacovm <yacovm@il.ibm.com>