### PR TITLE
Sync support

### DIFF
--- a/internal/bft/mocks/failure_detector.go
+++ b/internal/bft/mocks/failure_detector.go
@@ -9,7 +9,7 @@ type FailureDetector struct {
 	mock.Mock
 }
 
-// Complain provides a mock function with given fields:
-func (_m *FailureDetector) Complain() {
-	_m.Called()
+// Complain provides a mock function with given fields: stopView
+func (_m *FailureDetector) Complain(stopView bool) {
+	_m.Called(stopView)
 }

--- a/internal/bft/view_test.go
+++ b/internal/bft/view_test.go
@@ -173,7 +173,7 @@ func TestBadPrePrepare(t *testing.T) {
 				syncWG.Wait()
 				synchronizer.AssertCalled(t, "Sync")
 				fdWG.Wait()
-				fd.AssertCalled(t, "Complain")
+				fd.AssertCalled(t, "Complain", false)
 			},
 		},
 		{
@@ -201,7 +201,7 @@ func TestBadPrePrepare(t *testing.T) {
 				syncWG.Wait()
 				synchronizer.AssertCalled(t, "Sync")
 				fdWG.Wait()
-				fd.AssertCalled(t, "Complain")
+				fd.AssertCalled(t, "Complain", false)
 			},
 		},
 		{
@@ -219,7 +219,7 @@ func TestBadPrePrepare(t *testing.T) {
 				syncWG.Wait()
 				synchronizer.AssertCalled(t, "Sync")
 				fdWG.Wait()
-				fd.AssertCalled(t, "Complain")
+				fd.AssertCalled(t, "Complain", false)
 			},
 		},
 		{
@@ -250,7 +250,7 @@ func TestBadPrePrepare(t *testing.T) {
 				syncWG.Wait()
 				synchronizer.AssertCalled(t, "Sync")
 				fdWG.Wait()
-				fd.AssertCalled(t, "Complain")
+				fd.AssertCalled(t, "Complain", false)
 			},
 		},
 		{
@@ -271,7 +271,7 @@ func TestBadPrePrepare(t *testing.T) {
 				syncWG.Wait()
 				synchronizer.AssertCalled(t, "Sync")
 				fdWG.Wait()
-				fd.AssertCalled(t, "Complain")
+				fd.AssertCalled(t, "Complain", false)
 			},
 		},
 		{
@@ -289,7 +289,7 @@ func TestBadPrePrepare(t *testing.T) {
 				syncWG.Wait()
 				synchronizer.AssertCalled(t, "Sync")
 				fdWG.Wait()
-				fd.AssertCalled(t, "Complain")
+				fd.AssertCalled(t, "Complain", false)
 			},
 		},
 	} {

--- a/internal/bft/viewchanger_test.go
+++ b/internal/bft/viewchanger_test.go
@@ -11,20 +11,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SmartBFT-Go/consensus/internal/bft"
+	"github.com/SmartBFT-Go/consensus/internal/bft/mocks"
 	"github.com/SmartBFT-Go/consensus/pkg/types"
-
-	"github.com/pkg/errors"
-	"go.uber.org/zap/zapcore"
-
-	"github.com/golang/protobuf/proto"
-
 	protos "github.com/SmartBFT-Go/consensus/smartbftprotos"
+	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
-
-	"github.com/SmartBFT-Go/consensus/internal/bft"
-	"github.com/SmartBFT-Go/consensus/internal/bft/mocks"
+	"go.uber.org/zap/zapcore"
 )
 
 var (
@@ -116,7 +112,7 @@ func TestStartViewChange(t *testing.T) {
 
 	vc.Start(0)
 
-	vc.StartViewChange()
+	vc.StartViewChange(true)
 	msg := <-msgChan
 	assert.NotNil(t, msg.GetViewChange())
 
@@ -552,7 +548,7 @@ func TestResendViewChangeMessage(t *testing.T) {
 
 	vc.Start(0)
 
-	vc.StartViewChange()
+	vc.StartViewChange(true)
 	m := <-msgChan
 	assert.NotNil(t, m.GetViewChange())
 

--- a/test/network.go
+++ b/test/network.go
@@ -8,9 +8,8 @@ package test
 import (
 	"fmt"
 	"math/rand"
-	"time"
-
 	"sync"
+	"time"
 
 	"github.com/SmartBFT-Go/consensus/smartbftprotos"
 	"github.com/golang/protobuf/proto"
@@ -52,6 +51,7 @@ func (n Network) AddOrUpdateNode(id uint64, h handler) {
 	}
 	n[id] = node
 	node.running.Add(1)
+	node.createCommittedBatches(n)
 	go node.serve()
 }
 
@@ -93,6 +93,7 @@ type Node struct {
 	shutdownChan    chan struct{}
 	in              chan msgFrom
 	h               handler
+	cb              *committedBatches
 }
 
 func (node *Node) SendConsensus(targetID uint64, m *smartbftprotos.Message) {
@@ -129,4 +130,14 @@ func (node *Node) serve() {
 
 		}
 	}
+}
+
+func (node *Node) createCommittedBatches(network Network) {
+	for _, n := range network {
+		if n.cb != nil {
+			node.cb = n.cb
+			return
+		}
+	}
+	node.cb = &committedBatches{}
 }

--- a/test/test_app.go
+++ b/test/test_app.go
@@ -7,6 +7,8 @@ package test
 
 import (
 	"encoding/asn1"
+	"fmt"
+	"sync"
 	"time"
 
 	"github.com/SmartBFT-Go/consensus/pkg/consensus"
@@ -43,7 +45,15 @@ func (a *App) Submit(req Request) {
 }
 
 func (a *App) Sync() (smartbftprotos.ViewMetadata, uint64) {
-	panic("implement me")
+	records := a.Node.cb.readAll(*a.latestMD)
+	for _, record := range records {
+		proposal := types.Proposal{
+			Payload:  record.Batch.ToBytes(),
+			Metadata: record.Metadata,
+		}
+		a.Deliver(proposal, nil)
+	}
+	return *a.latestMD, 0
 }
 
 func (a *App) Restart() {
@@ -117,13 +127,61 @@ func (a *App) AssembleProposal(metadata []byte, requests [][]byte) (nextProp typ
 	}, nil
 }
 
-func (a *App) Deliver(proposal types.Proposal, signature []types.Signature) {
-	a.Delivered <- &AppRecord{
+func (a *App) Deliver(proposal types.Proposal, _ []types.Signature) {
+	record := &AppRecord{
 		Metadata: proposal.Metadata,
 		Batch:    BatchFromBytes(proposal.Payload),
 	}
+	a.Node.cb.add(record)
 	a.latestMD = &smartbftprotos.ViewMetadata{}
 	proto.Unmarshal(proposal.Metadata, a.latestMD)
+	fmt.Println(a.ID, "Deliver(", a.latestMD.LatestSequence, ")")
+	a.Delivered <- record
+}
+
+type committedBatches struct {
+	lock     sync.RWMutex
+	latestMD smartbftprotos.ViewMetadata
+	records  []*AppRecord
+}
+
+func (cb *committedBatches) add(record *AppRecord) {
+	cb.lock.Lock()
+	defer cb.lock.Unlock()
+
+	md := &smartbftprotos.ViewMetadata{}
+	proto.Unmarshal(record.Metadata, md)
+
+	if cb.latestMD.ViewId > md.ViewId {
+		return
+	}
+	if cb.latestMD.LatestSequence >= md.LatestSequence {
+		return
+	}
+	cb.latestMD = *md
+	cb.records = append(cb.records, record)
+}
+
+func (cb *committedBatches) readAll(from smartbftprotos.ViewMetadata) []*AppRecord {
+	cb.lock.RLock()
+	defer cb.lock.RUnlock()
+
+	var res []*AppRecord
+
+	for _, entry := range cb.records {
+		md := &smartbftprotos.ViewMetadata{}
+		if err := proto.Unmarshal(entry.Metadata, md); err != nil {
+			panic(err)
+		}
+		if md.ViewId < from.ViewId || md.LatestSequence <= from.LatestSequence {
+			continue
+		}
+		res = append(res, &AppRecord{
+			Metadata: entry.Metadata,
+			Batch:    entry.Batch,
+		})
+	}
+	return res
 }
 
 type Request struct {

--- a/test/test_app.go
+++ b/test/test_app.go
@@ -150,7 +150,9 @@ func (cb *committedBatches) add(record *AppRecord) {
 	defer cb.lock.Unlock()
 
 	md := &smartbftprotos.ViewMetadata{}
-	proto.Unmarshal(record.Metadata, md)
+	if err := proto.Unmarshal(record.Metadata, md); err != nil {
+		panic(err)
+	}
 
 	if cb.latestMD.ViewId > md.ViewId {
 		return


### PR DESCRIPTION
This commit adds sync support to the view:

- Whenever we get a message from the future from the leader of a view,
  we complain and then call Sync() from the view.
- The Sync triggers the controller to stop the current view,
  and start a new one with the view info returned from Sync().
- The Complain() now has an additional parameter which mentions
  whether the view changer is expected to close the view itself or not.
  This is to prevent the new view started after Sync() to be
  terminated right after it started by the view changer.

Signed-off-by: yacovm <yacovm@il.ibm.com>