### PR TITLE
Abort Delivery if controller stopped

### DIFF
--- a/internal/bft/controller.go
+++ b/internal/bft/controller.go
@@ -512,7 +512,11 @@ func (c *Controller) Decide(proposal types.Proposal, signatures []types.Signatur
 		return
 	}
 
-	<-c.deliverChan // wait for the delivery of the decision to the application
+	select {
+	case <-c.deliverChan: // wait for the delivery of the decision to the application
+	case <-c.stopChan: // If we stopped the controller, abort delivery
+	}
+
 }
 
 func (c *Controller) removeDeliveredFromPool(d decision) {


### PR DESCRIPTION
When stopping the controller it might be in the middle of deliverin
to the application, and the stop operation would wait for all
goroutines to wait, which will never happen because there might be
no one reading from the delivery channel at the time.

This change simply makes the controller abort delivery to the app
if it is stopped.

Signed-off-by: yacovm <yacovm@il.ibm.com>