### PR TITLE
ignore old complains

### DIFF
--- a/internal/bft/controller.go
+++ b/internal/bft/controller.go
@@ -21,7 +21,7 @@ type Decider interface {
 
 //go:generate mockery -dir . -name FailureDetector -case underscore -output ./mocks/
 type FailureDetector interface {
-	Complain(stopView bool)
+	Complain(viewNum uint64, stopView bool)
 }
 
 //go:generate mockery -dir . -name Batcher -case underscore -output ./mocks/
@@ -196,7 +196,7 @@ func (c *Controller) OnLeaderFwdRequestTimeout(request []byte, info types.Reques
 	}
 
 	c.Logger.Warnf("Request %s leader-forwarding timeout expired, complaining about leader: %d", info, leaderID)
-	c.FailureDetector.Complain(true)
+	c.FailureDetector.Complain(c.getCurrentViewNumber(), true)
 
 	return
 }
@@ -225,7 +225,7 @@ func (c *Controller) OnHeartbeatTimeout(view uint64, leaderID uint64) {
 	}
 
 	c.Logger.Warnf("Heartbeat timeout expired, complaining about leader: %d", leaderID)
-	c.FailureDetector.Complain(true)
+	c.FailureDetector.Complain(c.getCurrentViewNumber(), true)
 }
 
 // ProcessMessages dispatches the incoming message to the required component

--- a/internal/bft/controller_test.go
+++ b/internal/bft/controller_test.go
@@ -503,7 +503,7 @@ func TestSyncInform(t *testing.T) {
 	controller.Start(1, 0)
 	vc.Start(1)
 
-	vc.StartViewChange(true)
+	vc.StartViewChange(1, true)
 	msg := <-msgChan
 	assert.NotNil(t, msg.GetViewChange())
 	assert.Equal(t, uint64(2), msg.GetViewChange().NextView) // view number as expected
@@ -517,7 +517,7 @@ func TestSyncInform(t *testing.T) {
 	assembler.AssertNumberOfCalls(t, "AssembleProposal", 1)
 	comm.AssertNumberOfCalls(t, "BroadcastConsensus", 2)
 
-	vc.StartViewChange(true)
+	vc.StartViewChange(2, true)
 	msg = <-msgChan
 	assert.NotNil(t, msg.GetViewChange())
 	assert.Equal(t, syncToView+1, msg.GetViewChange().NextView) // view number did change according to info

--- a/internal/bft/mocks/failure_detector.go
+++ b/internal/bft/mocks/failure_detector.go
@@ -9,7 +9,7 @@ type FailureDetector struct {
 	mock.Mock
 }
 
-// Complain provides a mock function with given fields: stopView
-func (_m *FailureDetector) Complain(stopView bool) {
-	_m.Called(stopView)
+// Complain provides a mock function with given fields: viewNum, stopView
+func (_m *FailureDetector) Complain(viewNum uint64, stopView bool) {
+	_m.Called(viewNum, stopView)
 }

--- a/internal/bft/view.go
+++ b/internal/bft/view.go
@@ -170,7 +170,7 @@ func (v *View) processMsg(sender uint64, m *protos.Message) {
 			v.discoverIfSyncNeeded(sender, m)
 			return
 		}
-		v.FailureDetector.Complain(false)
+		v.FailureDetector.Complain(v.Number, false)
 		// Else, we got a message with a wrong view from the leader.
 		if msgViewNum > v.Number {
 			v.Sync.Sync()
@@ -336,7 +336,7 @@ func (v *View) processProposal() Phase {
 	requests, err := v.verifyProposal(proposal)
 	if err != nil {
 		v.Logger.Warnf("%d received bad proposal from %d: %v", v.SelfID, v.LeaderID, err)
-		v.FailureDetector.Complain(false)
+		v.FailureDetector.Complain(v.Number, false)
 		v.Sync.Sync()
 		v.stop()
 		return ABORT

--- a/internal/bft/view_test.go
+++ b/internal/bft/view_test.go
@@ -176,7 +176,7 @@ func TestBadPrePrepare(t *testing.T) {
 				syncWG.Wait()
 				synchronizer.AssertCalled(t, "Sync")
 				fdWG.Wait()
-				fd.AssertCalled(t, "Complain", false)
+				fd.AssertCalled(t, "Complain", uint64(1), false)
 			},
 		},
 		{
@@ -204,7 +204,7 @@ func TestBadPrePrepare(t *testing.T) {
 				syncWG.Wait()
 				synchronizer.AssertCalled(t, "Sync")
 				fdWG.Wait()
-				fd.AssertCalled(t, "Complain", false)
+				fd.AssertCalled(t, "Complain", uint64(1), false)
 			},
 		},
 		{
@@ -222,7 +222,7 @@ func TestBadPrePrepare(t *testing.T) {
 				syncWG.Wait()
 				synchronizer.AssertCalled(t, "Sync")
 				fdWG.Wait()
-				fd.AssertCalled(t, "Complain", false)
+				fd.AssertCalled(t, "Complain", uint64(1), false)
 			},
 		},
 		{
@@ -253,7 +253,7 @@ func TestBadPrePrepare(t *testing.T) {
 				syncWG.Wait()
 				synchronizer.AssertCalled(t, "Sync")
 				fdWG.Wait()
-				fd.AssertCalled(t, "Complain", false)
+				fd.AssertCalled(t, "Complain", uint64(1), false)
 			},
 		},
 		{
@@ -274,7 +274,7 @@ func TestBadPrePrepare(t *testing.T) {
 				syncWG.Wait()
 				synchronizer.AssertCalled(t, "Sync")
 				fdWG.Wait()
-				fd.AssertCalled(t, "Complain", false)
+				fd.AssertCalled(t, "Complain", uint64(1), false)
 			},
 		},
 		{
@@ -292,7 +292,7 @@ func TestBadPrePrepare(t *testing.T) {
 				syncWG.Wait()
 				synchronizer.AssertCalled(t, "Sync")
 				fdWG.Wait()
-				fd.AssertCalled(t, "Complain", false)
+				fd.AssertCalled(t, "Complain", uint64(1), false)
 			},
 		},
 	} {
@@ -315,7 +315,7 @@ func TestBadPrePrepare(t *testing.T) {
 			})
 			fd = &mocks.FailureDetector{}
 			fdWG = &sync.WaitGroup{}
-			fd.On("Complain", mock.Anything).Run(func(args mock.Arguments) {
+			fd.On("Complain", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 				fdWG.Done()
 			})
 			state := &bft.StateRecorder{}
@@ -395,7 +395,7 @@ func TestBadPrepare(t *testing.T) {
 			}).Return(protos.ViewMetadata{}, uint64(0))
 			fd := &mocks.FailureDetector{}
 			fdWG := &sync.WaitGroup{}
-			fd.On("Complain", mock.Anything).Run(func(args mock.Arguments) {
+			fd.On("Complain", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 				fdWG.Done()
 			})
 			comm := &mocks.CommMock{}

--- a/internal/bft/viewchanger.go
+++ b/internal/bft/viewchanger.go
@@ -281,7 +281,7 @@ func (v *ViewChanger) StartViewChange(view uint64, stopView bool) {
 
 // StartViewChange stops current view and timeouts, and broadcasts a view change message to all
 func (v *ViewChanger) startViewChange(change *change) {
-	if change.view+1 < v.currView { // this is about an old view
+	if change.view < v.currView { // this is about an old view
 		v.Logger.Warnf("Node %d has a view change request with an old view %d, while the current view is %d", v.SelfID, change.view, v.currView)
 		return
 	}

--- a/internal/bft/viewchanger.go
+++ b/internal/bft/viewchanger.go
@@ -282,7 +282,7 @@ func (v *ViewChanger) StartViewChange(view uint64, stopView bool) {
 // StartViewChange stops current view and timeouts, and broadcasts a view change message to all
 func (v *ViewChanger) startViewChange(change *change) {
 	if change.view < v.currView { // this is about an old view
-		v.Logger.Warnf("Node %d has a view change request with an old view %d, while the current view is %d", v.SelfID, change.view, v.currView)
+		v.Logger.Debugf("Node %d has a view change request with an old view %d, while the current view is %d", v.SelfID, change.view, v.currView)
 		return
 	}
 	v.nextView = v.currView + 1

--- a/internal/bft/viewchanger.go
+++ b/internal/bft/viewchanger.go
@@ -250,10 +250,6 @@ func (v *ViewChanger) processMsg(sender uint64, m *protos.Message) {
 
 // InformNewView tells the view changer to advance to a new view number
 func (v *ViewChanger) InformNewView(view uint64) {
-	if view <= v.currView {
-		v.Logger.Debugf("Node %d was informed of view %d, but the current view is %d", v.SelfID, view, v.currView)
-		return
-	}
 	select {
 	case v.informChan <- view:
 	case <-v.stopChan:
@@ -262,6 +258,10 @@ func (v *ViewChanger) InformNewView(view uint64) {
 }
 
 func (v *ViewChanger) informNewView(view uint64) {
+	if view <= v.currView {
+		v.Logger.Debugf("Node %d was informed of view %d, but the current view is %d", v.SelfID, view, v.currView)
+		return
+	}
 	v.Logger.Debugf("Node %d was informed of a new view %d", v.SelfID, view)
 	v.currView = view
 	v.nextView = v.currView

--- a/internal/bft/viewchanger.go
+++ b/internal/bft/viewchanger.go
@@ -29,6 +29,11 @@ type RequestsTimer interface {
 	RemoveRequest(request types.RequestInfo) error
 }
 
+type change struct {
+	view     uint64
+	stopView bool
+}
+
 type ViewChanger struct {
 	// Configuration
 	SelfID uint64
@@ -65,7 +70,7 @@ type ViewChanger struct {
 	currView        uint64
 	nextView        uint64
 	leader          uint64
-	startChangeChan chan bool
+	startChangeChan chan *change
 	informChan      chan uint64
 
 	stopOnce sync.Once
@@ -76,7 +81,7 @@ type ViewChanger struct {
 // Start the view changer
 func (v *ViewChanger) Start(startViewNumber uint64) {
 	v.incMsgs = make(chan *incMsg, 10*v.N) // TODO channel size should be configured
-	v.startChangeChan = make(chan bool, 1)
+	v.startChangeChan = make(chan *change, 1)
 	v.informChan = make(chan uint64, 1)
 
 	v.nodes = v.Comm.Nodes()
@@ -158,8 +163,8 @@ func (v *ViewChanger) run() {
 		select {
 		case <-v.stopChan:
 			return
-		case stopView := <-v.startChangeChan:
-			v.startViewChange(stopView)
+		case change := <-v.startChangeChan:
+			v.startViewChange(change)
 		case msg := <-v.incMsgs:
 			v.processMsg(msg.sender, msg.Message)
 		case now := <-v.Ticker:
@@ -204,7 +209,7 @@ func (v *ViewChanger) checkIfTimeout(now time.Time) {
 	v.checkTimeout = false // stop timeout for now, a new one will start when a new view change begins
 	// the timeout has passed, something went wrong, try sync and complain
 	v.Synchronizer.Sync()
-	v.StartViewChange(false) // don't stop the view, the sync maybe created a good view
+	v.StartViewChange(v.currView, false) // don't stop the view, the sync maybe created a good view
 }
 
 func (v *ViewChanger) processMsg(sender uint64, m *protos.Message) {
@@ -267,15 +272,19 @@ func (v *ViewChanger) informNewView(view uint64) {
 }
 
 // StartViewChange initiates a view change
-func (v *ViewChanger) StartViewChange(stopView bool) {
+func (v *ViewChanger) StartViewChange(view uint64, stopView bool) {
 	select {
-	case v.startChangeChan <- stopView:
+	case v.startChangeChan <- &change{view: view, stopView: stopView}:
 	default:
 	}
 }
 
 // StartViewChange stops current view and timeouts, and broadcasts a view change message to all
-func (v *ViewChanger) startViewChange(stopView bool) {
+func (v *ViewChanger) startViewChange(change *change) {
+	if change.view+1 < v.currView { // this is about an old view
+		v.Logger.Warnf("Node %d has a view change request with an old view %d, while the current view is %d", v.SelfID, change.view, v.currView)
+		return
+	}
 	v.nextView = v.currView + 1
 	v.RequestsTimer.StopTimers()
 	msg := &protos.Message{
@@ -288,7 +297,7 @@ func (v *ViewChanger) startViewChange(stopView bool) {
 	}
 	v.Comm.BroadcastConsensus(msg)
 	v.Logger.Debugf("Node %d started view change, last view is %d", v.SelfID, v.currView)
-	if stopView {
+	if change.stopView {
 		v.Controller.AbortView() // abort the current view when joining view change
 	}
 	v.startViewChangeTime = v.lastTick
@@ -298,7 +307,7 @@ func (v *ViewChanger) startViewChange(stopView bool) {
 func (v *ViewChanger) processViewChangeMsg() {
 	if uint64(len(v.viewChangeMsgs.voted)) == uint64(v.f+1) { // join view change
 		v.Logger.Debugf("Node %d is joining view change, last view is %d", v.SelfID, v.currView)
-		v.startViewChange(true)
+		v.startViewChange(&change{v.currView, true})
 	}
 	// TODO add view change try timeout
 	if len(v.viewChangeMsgs.voted) >= v.quorum-1 && v.nextView > v.currView { // send view data

--- a/internal/bft/viewchanger_test.go
+++ b/internal/bft/viewchanger_test.go
@@ -112,7 +112,7 @@ func TestStartViewChange(t *testing.T) {
 
 	vc.Start(0)
 
-	vc.StartViewChange(true)
+	vc.StartViewChange(0, true)
 	msg := <-msgChan
 	assert.NotNil(t, msg.GetViewChange())
 
@@ -557,7 +557,7 @@ func TestResendViewChangeMessage(t *testing.T) {
 	vc.Start(0)
 	startTime := time.Now()
 
-	vc.StartViewChange(true)
+	vc.StartViewChange(0, true)
 	m := <-msgChan
 	assert.NotNil(t, m.GetViewChange())
 
@@ -623,7 +623,7 @@ func TestViewChangerTimeout(t *testing.T) {
 
 	controllerWG.Add(1)
 	reqTimerWG.Add(1)
-	vc.StartViewChange(true) // start timer
+	vc.StartViewChange(0, true) // start timer
 	controllerWG.Wait()
 	reqTimerWG.Wait()
 
@@ -1016,7 +1016,7 @@ func TestInformViewChanger(t *testing.T) {
 	info := uint64(2)
 	vc.InformNewView(info) // increase the view number
 
-	vc.StartViewChange(true)
+	vc.StartViewChange(2, true)
 	msg := <-msgChan
 	assert.NotNil(t, msg.GetViewChange())
 	assert.Equal(t, info+1, msg.GetViewChange().NextView) // view number did change according to info

--- a/internal/bft/viewchanger_test.go
+++ b/internal/bft/viewchanger_test.go
@@ -1015,6 +1015,7 @@ func TestInformViewChanger(t *testing.T) {
 
 	info := uint64(2)
 	vc.InformNewView(info) // increase the view number
+	vc.InformNewView(info) // make sure that inform happened (channel size is 1)
 
 	vc.StartViewChange(2, true)
 	msg := <-msgChan

--- a/pkg/consensus/consensus.go
+++ b/pkg/consensus/consensus.go
@@ -50,8 +50,8 @@ type Consensus struct {
 	n           uint64
 }
 
-func (c *Consensus) Complain(stopView bool) {
-	c.viewChanger.StartViewChange(stopView)
+func (c *Consensus) Complain(viewNum uint64, stopView bool) {
+	c.viewChanger.StartViewChange(viewNum, stopView)
 }
 
 func (c *Consensus) Deliver(proposal types.Proposal, signatures []types.Signature) {


### PR DESCRIPTION
This can happen for example when the heartbeat monitor complains after a timeout about an old leader when we are already in the process of view change because of that leader, so there is no reason to send another view change message.