### PR TITLE
In-Msg-Q size config in view-changer

### DIFF
--- a/internal/bft/controller_test.go
+++ b/internal/bft/controller_test.go
@@ -486,6 +486,7 @@ func TestSyncInform(t *testing.T) {
 		RequestsTimer: reqTimer,
 		Ticker:        make(chan time.Time),
 		Controller:    controllerMock,
+		InMsqQSize:    100,
 	}
 
 	controller := &bft.Controller{

--- a/internal/bft/viewchanger.go
+++ b/internal/bft/viewchanger.go
@@ -64,6 +64,7 @@ type ViewChanger struct {
 	checkTimeout        bool
 
 	// Runtime
+	InMsqQSize      int
 	incMsgs         chan *incMsg
 	viewChangeMsgs  *voteSet
 	viewDataMsgs    *voteSet
@@ -80,7 +81,7 @@ type ViewChanger struct {
 
 // Start the view changer
 func (v *ViewChanger) Start(startViewNumber uint64) {
-	v.incMsgs = make(chan *incMsg, 10*v.N) // TODO channel size should be configured
+	v.incMsgs = make(chan *incMsg, v.InMsqQSize)
 	v.startChangeChan = make(chan *change, 1)
 	v.informChan = make(chan uint64, 1)
 

--- a/internal/bft/viewchanger_test.go
+++ b/internal/bft/viewchanger_test.go
@@ -73,9 +73,10 @@ func TestViewChangerBasic(t *testing.T) {
 	comm.On("Nodes").Return([]uint64{0, 1, 2, 3})
 
 	vc := &bft.ViewChanger{
-		N:      4,
-		Comm:   comm,
-		Ticker: make(chan time.Time),
+		N:          4,
+		Comm:       comm,
+		Ticker:     make(chan time.Time),
+		InMsqQSize: 100,
 	}
 
 	vc.Start(0)
@@ -108,6 +109,7 @@ func TestStartViewChange(t *testing.T) {
 		Ticker:        make(chan time.Time),
 		Logger:        log,
 		Controller:    controller,
+		InMsqQSize:    100,
 	}
 
 	vc.Start(0)
@@ -158,6 +160,7 @@ func TestViewChangeProcess(t *testing.T) {
 		InFlight:      &bft.InFlightData{},
 		Checkpoint:    &types.Checkpoint{},
 		Controller:    controller,
+		InMsqQSize:    100,
 	}
 
 	vc.Start(0)
@@ -243,6 +246,7 @@ func TestViewDataProcess(t *testing.T) {
 		Ticker:        make(chan time.Time),
 		Checkpoint:    &checkpoint,
 		RequestsTimer: reqTimer,
+		InMsqQSize:    100,
 	}
 
 	vc.Start(1)
@@ -322,6 +326,7 @@ func TestNewViewProcess(t *testing.T) {
 		Ticker:        make(chan time.Time),
 		Checkpoint:    &checkpoint,
 		RequestsTimer: reqTimer,
+		InMsqQSize:    100,
 	}
 
 	vc.Start(2)
@@ -412,6 +417,7 @@ func TestNormalProcess(t *testing.T) {
 		Ticker:        make(chan time.Time),
 		InFlight:      &bft.InFlightData{},
 		Checkpoint:    &checkpoint,
+		InMsqQSize:    100,
 	}
 
 	vc.Start(0)
@@ -504,12 +510,13 @@ func TestBadViewDataMessage(t *testing.T) {
 			test.mutateVerifySig(verifier)
 			verifier.On("VerifySignature", mock.Anything).Return(nil)
 			vc := &bft.ViewChanger{
-				SelfID:   2,
-				N:        4,
-				Comm:     comm,
-				Logger:   log,
-				Verifier: verifier,
-				Ticker:   make(chan time.Time),
+				SelfID:     2,
+				N:          4,
+				Comm:       comm,
+				Logger:     log,
+				Verifier:   verifier,
+				Ticker:     make(chan time.Time),
+				InMsqQSize: 100,
 			}
 
 			vc.Start(1)
@@ -552,6 +559,7 @@ func TestResendViewChangeMessage(t *testing.T) {
 		Controller:        controller,
 		ResendTimeout:     time.Second,
 		TimeoutViewChange: 10 * time.Second,
+		InMsqQSize:        100,
 	}
 
 	vc.Start(0)
@@ -616,6 +624,7 @@ func TestViewChangerTimeout(t *testing.T) {
 		ResendTimeout:     20 * time.Second,
 		Synchronizer:      synchronizer,
 		Controller:        controller,
+		InMsqQSize:        100,
 	}
 
 	vc.Start(0)
@@ -690,6 +699,7 @@ func TestCommitLastDecision(t *testing.T) {
 		InFlight:      &bft.InFlightData{},
 		Checkpoint:    &checkpoint,
 		Application:   app,
+		InMsqQSize:    100,
 	}
 
 	vc.Start(0)
@@ -801,6 +811,7 @@ func TestInFlightProposalInViewData(t *testing.T) {
 				InFlight:      test.getInFlight(),
 				Checkpoint:    &checkpoint,
 				Controller:    controller,
+				InMsqQSize:    100,
 			}
 
 			vc.Start(0)
@@ -1009,6 +1020,7 @@ func TestInformViewChanger(t *testing.T) {
 		Ticker:        make(chan time.Time),
 		Logger:        log,
 		Controller:    controller,
+		InMsqQSize:    100,
 	}
 
 	vc.Start(0)

--- a/pkg/consensus/consensus.go
+++ b/pkg/consensus/consensus.go
@@ -80,6 +80,7 @@ func (c *Consensus) Start() {
 		Ticker:            c.ViewChangerTicker,
 		ResendTimeout:     c.Config.ViewChangeResendInterval,
 		TimeoutViewChange: c.Config.ViewChangeTimeout,
+		InMsqQSize:        c.Config.IncomingMessageBufferSize,
 	}
 
 	c.controller = &algorithm.Controller{


### PR DESCRIPTION
Make the in-message-queue channel size configurable
in viewchanger.go and consensus.go, and respective tests.

Signed-off-by: Yoav Tock <tock@il.ibm.com>