### PR TITLE
Fail fast if request already exists in pool

### DIFF
--- a/internal/bft/requestpool_test.go
+++ b/internal/bft/requestpool_test.go
@@ -471,7 +471,7 @@ func TestReqPoolTimeout(t *testing.T) {
 
 		pool.RestartTimers()
 		err = pool.Submit(byteReq2)
-		assert.EqualError(t, err, "request {2 2} already exists in the pool")
+		assert.Equal(t, bft.ErrReqAlreadyExists, err)
 		pool.StopTimers()
 		pool.RestartTimers()
 


### PR DESCRIPTION
When adding a new request to the pool, there is no need to wait on the semaphore
in case the request already exists, as it is already scheduled to be either picked
by the batcher or to be forwarded to the leader.

This commit returns early in case the request that is about to be added, already exists
in the request pool.

Signed-off-by: Yacov Manevich <yacovm@il.ibm.com>