### PR TITLE
Add request pool configurations

### DIFF
--- a/internal/bft/requestpool_test.go
+++ b/internal/bft/requestpool_test.go
@@ -7,6 +7,7 @@ package bft_test
 
 import (
 	"bytes"
+	"crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"sync"
@@ -291,6 +292,33 @@ func TestReqPoolTimeout(t *testing.T) {
 	insp := &testRequestInspector{}
 	submittedChan := make(chan struct{}, 1)
 
+	t.Run("request size too big", func(t *testing.T) {
+		timeoutHandler := &mocks.RequestTimeoutHandler{}
+
+		timeoutHandler.On("OnRequestTimeout", byteReq1, insp.RequestID(byteReq1)).Return()
+		timeoutHandler.On("OnLeaderFwdRequestTimeout", byteReq1, insp.RequestID(byteReq1)).Return()
+		timeoutHandler.On("OnAutoRemoveTimeout", insp.RequestID(byteReq1)).Return()
+
+		pool := bft.NewPool(log, insp, timeoutHandler,
+			bft.PoolOptions{
+				QueueSize:         3,
+				ForwardTimeout:    10 * time.Millisecond,
+				ComplainTimeout:   time.Hour,
+				AutoRemoveTimeout: time.Hour,
+				RequestMaxBytes:   1024,
+			},
+			nil,
+		)
+		defer pool.Close()
+
+		payload := make([]byte, 2048)
+		rand.Read(payload)
+		request := makeTestRequest("1", "1", string(payload))
+		assert.Equal(t, 0, pool.Size())
+		err = pool.Submit(request)
+		assert.Equal(t, err, bft.ErrRequestTooBig)
+
+	})
 	t.Run("request timeout", func(t *testing.T) {
 		timeoutHandler := &mocks.RequestTimeoutHandler{}
 

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -77,6 +77,13 @@ type Configuration struct {
 	LeaderRotation bool
 	// DecisionsPerLeader is the number of decisions reached by a leader before there is a leader rotation.
 	DecisionsPerLeader uint64
+
+	// RequestMaxBytes total allowed size of the single request
+	RequestMaxBytes uint64
+
+	// RequestPoolSubmitTimeout the total amount of time client can wait for submission of single
+	// request into request pool
+	RequestPoolSubmitTimeout time.Duration
 }
 
 // DefaultConfig contains reasonable values for a small cluster that resides on the same geography (or "Region"), but
@@ -102,6 +109,8 @@ var DefaultConfig = Configuration{
 	SpeedUpViewChange:             false,
 	LeaderRotation:                true,
 	DecisionsPerLeader:            3,
+	RequestMaxBytes:               10 * 1024,
+	RequestPoolSubmitTimeout:      5 * time.Second,
 }
 
 func (c Configuration) Validate() error {
@@ -165,6 +174,14 @@ func (c Configuration) Validate() error {
 	}
 	if c.LeaderRotation && c.DecisionsPerLeader <= 0 {
 		return errors.Errorf("DecisionsPerLeader should be greater than zero when leader rotation is active")
+	}
+
+	if !(c.RequestMaxBytes > 0) {
+		return errors.Errorf("RequestMaxBytes should be greater than zero")
+	}
+
+	if !(c.RequestPoolSubmitTimeout > 0) {
+		return errors.Errorf("RequestPoolSubmitTimeout should be greater than zero")
 	}
 
 	return nil


### PR DESCRIPTION
This commit adds two new configuration paramaters for request pool:

1. Maximum size of the incomming request
2. Timeout to wait for request submission

Signed-off-by: Artem Barger <artem@bargr.net>