### PR TITLE
Add configuration to control request pool parameters

### DIFF
--- a/internal/bft/requestpool_test.go
+++ b/internal/bft/requestpool_test.go
@@ -7,6 +7,7 @@ package bft_test
 
 import (
 	"bytes"
+	"crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"sync"
@@ -291,6 +292,33 @@ func TestReqPoolTimeout(t *testing.T) {
 	insp := &testRequestInspector{}
 	submittedChan := make(chan struct{}, 1)
 
+	t.Run("request size too big", func(t *testing.T) {
+		timeoutHandler := &mocks.RequestTimeoutHandler{}
+
+		timeoutHandler.On("OnRequestTimeout", byteReq1, insp.RequestID(byteReq1)).Return()
+		timeoutHandler.On("OnLeaderFwdRequestTimeout", byteReq1, insp.RequestID(byteReq1)).Return()
+		timeoutHandler.On("OnAutoRemoveTimeout", insp.RequestID(byteReq1)).Return()
+
+		pool := bft.NewPool(log, insp, timeoutHandler,
+			bft.PoolOptions{
+				QueueSize:         3,
+				ForwardTimeout:    10 * time.Millisecond,
+				ComplainTimeout:   time.Hour,
+				AutoRemoveTimeout: time.Hour,
+				RequestMaxBytes:   1024,
+			},
+			nil,
+		)
+		defer pool.Close()
+
+		payload := make([]byte, 2048)
+		rand.Read(payload)
+		request := makeTestRequest("1", "1", string(payload))
+		assert.Equal(t, 0, pool.Size())
+		err = pool.Submit(request)
+		assert.Equal(t, err, bft.ErrRequestTooBig)
+
+	})
 	t.Run("request timeout", func(t *testing.T) {
 		timeoutHandler := &mocks.RequestTimeoutHandler{}
 

--- a/pkg/consensus/consensus.go
+++ b/pkg/consensus/consensus.go
@@ -216,6 +216,8 @@ func (c *Consensus) reconfig(reconfig types.Reconfig) {
 		ForwardTimeout:    c.Config.RequestForwardTimeout,
 		ComplainTimeout:   c.Config.RequestComplainTimeout,
 		AutoRemoveTimeout: c.Config.RequestAutoRemoveTimeout,
+		RequestMaxBytes:   c.Config.RequestMaxBytes,
+		SubmitTimeout:     c.Config.RequestPoolSubmitTimeout,
 	}
 	c.Pool.ChangeTimeouts(c.controller, opts) // TODO handle reconfiguration of queue size in the pool
 	c.continueCreateComponents()

--- a/pkg/consensus/consensus.go
+++ b/pkg/consensus/consensus.go
@@ -134,6 +134,8 @@ func (c *Consensus) Start() error {
 		ForwardTimeout:    c.Config.RequestForwardTimeout,
 		ComplainTimeout:   c.Config.RequestComplainTimeout,
 		AutoRemoveTimeout: c.Config.RequestAutoRemoveTimeout,
+		RequestMaxBytes:   c.Config.RequestMaxBytes,
+		SubmitTimeout:     c.Config.RequestPoolSubmitTimeout,
 	}
 	c.submittedChan = make(chan struct{}, 1)
 	c.Pool = algorithm.NewPool(c.Logger, c.RequestInspector, c.controller, opts, c.submittedChan)

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -77,6 +77,13 @@ type Configuration struct {
 	LeaderRotation bool
 	// DecisionsPerLeader is the number of decisions reached by a leader before there is a leader rotation.
 	DecisionsPerLeader uint64
+
+	// RequestMaxBytes total allowed size of the single request
+	RequestMaxBytes uint64
+
+	// RequestPoolSubmitTimeout the total amount of time client can wait for submission of single
+	// request into request pool
+	RequestPoolSubmitTimeout time.Duration
 }
 
 // DefaultConfig contains reasonable values for a small cluster that resides on the same geography (or "Region"), but
@@ -102,6 +109,8 @@ var DefaultConfig = Configuration{
 	SpeedUpViewChange:             false,
 	LeaderRotation:                true,
 	DecisionsPerLeader:            3,
+	RequestMaxBytes:               10 * 1024,
+	RequestPoolSubmitTimeout:      5 * time.Second,
 }
 
 func (c Configuration) Validate() error {
@@ -165,6 +174,14 @@ func (c Configuration) Validate() error {
 	}
 	if c.LeaderRotation && c.DecisionsPerLeader <= 0 {
 		return errors.Errorf("DecisionsPerLeader should be greater than zero when leader rotation is active")
+	}
+
+	if !(c.RequestMaxBytes > 0) {
+		return errors.Errorf("RequestMaxBytes should be greater than zero")
+	}
+
+	if !(c.RequestPoolSubmitTimeout > 0) {
+		return errors.Errorf("RequestPoolSubmitTimeout should be greater than zero")
 	}
 
 	return nil

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -6,6 +6,7 @@
 package types
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -177,7 +178,8 @@ func (c Configuration) Validate() error {
 	}
 
 	if !(c.RequestMaxBytes > 0) {
-		return errors.Errorf("RequestMaxBytes should be greater than zero")
+		panic(fmt.Sprintf("%v", c))
+		// return errors.Errorf("RequestMaxBytes should be greater than zero")
 	}
 
 	if !(c.RequestPoolSubmitTimeout > 0) {

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -6,7 +6,6 @@
 package types
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -178,8 +177,7 @@ func (c Configuration) Validate() error {
 	}
 
 	if !(c.RequestMaxBytes > 0) {
-		panic(fmt.Sprintf("%v", c))
-		// return errors.Errorf("RequestMaxBytes should be greater than zero")
+		return errors.Errorf("RequestMaxBytes should be greater than zero")
 	}
 
 	if !(c.RequestPoolSubmitTimeout > 0) {

--- a/test/reconfig.go
+++ b/test/reconfig.go
@@ -26,6 +26,8 @@ type Configuration struct {
 	SpeedUpViewChange             bool
 	LeaderRotation                bool
 	DecisionsPerLeader            int64
+	RequestMaxBytes               int64
+	RequestPoolSubmitTimeout      time.Duration
 }
 
 type Reconfig struct {
@@ -58,6 +60,8 @@ func (r Reconfig) recconfigToUint(id uint64) types.Reconfig {
 			SpeedUpViewChange:             r.CurrentConfig.SpeedUpViewChange,
 			LeaderRotation:                r.CurrentConfig.LeaderRotation,
 			DecisionsPerLeader:            uint64(r.CurrentConfig.DecisionsPerLeader),
+			RequestMaxBytes:               uint64(r.CurrentConfig.RequestBatchMaxBytes),
+			RequestPoolSubmitTimeout:      r.CurrentConfig.RequestPoolSubmitTimeout,
 		},
 	}
 }
@@ -85,6 +89,8 @@ func recconfigToInt(reconfig types.Reconfig) Reconfig {
 			SpeedUpViewChange:             reconfig.CurrentConfig.SpeedUpViewChange,
 			LeaderRotation:                reconfig.CurrentConfig.LeaderRotation,
 			DecisionsPerLeader:            int64(reconfig.CurrentConfig.DecisionsPerLeader),
+			RequestMaxBytes:               int64(reconfig.CurrentConfig.RequestBatchMaxBytes),
+			RequestPoolSubmitTimeout:      reconfig.CurrentConfig.RequestPoolSubmitTimeout,
 		},
 	}
 }

--- a/test/test_app.go
+++ b/test/test_app.go
@@ -38,6 +38,8 @@ var fastConfig = types.Configuration{
 	NumOfTicksBehindBeforeSyncing: 10,
 	CollectTimeout:                200 * time.Millisecond,
 	LeaderRotation:                false,
+	RequestMaxBytes:               10 * 1024,
+	RequestPoolSubmitTimeout:      5 * time.Second,
 }
 
 // App implements all interfaces required by an application using this library


### PR DESCRIPTION
Add two parameters:

1. Control maximum size of the request payload allowed for RequestPool
2. Timeout to wait for request submission in case pool is exhausted. 