### PR TITLE
Restart request pool timers when leader rotates

### DIFF
--- a/internal/bft/controller.go
+++ b/internal/bft/controller.go
@@ -508,6 +508,8 @@ func (c *Controller) decide(d decision) {
 	if c.checkIfRotate(md.BlackList) {
 		c.Logger.Debugf("Restarting view to rotate the leader")
 		c.changeView(c.getCurrentViewNumber(), md.LatestSequence+1, c.getCurrentDecisionsInView())
+		c.Logger.Debugf("Restarting timers in request pool due to leader rotation")
+		c.RequestPool.RestartTimers()
 	}
 	c.MaybePruneRevokedRequests()
 	if iAm, _ := c.iAmTheLeader(); iAm {


### PR DESCRIPTION
When the leader rotates due to a block commit, any request that has fired a first timeout
is waiting either for the request to be included in some block, or it will trigger
lobbying for a view change.

This is wrong, because the timeout might have originated from a previous leader and this leader
might be honest but just didn't have enough time to include the request in a block.

This commit resets the timeout upon every leader rotation, to give a fair amount of time
for all leader nodes to schedule pending requests.

Signed-off-by: Yacov Manevich <yacovm@il.ibm.com>