### PR TITLE
Fix bug stuck in propose

### DIFF
--- a/internal/bft/controller_test.go
+++ b/internal/bft/controller_test.go
@@ -584,6 +584,7 @@ func TestControllerLeaderRequestHandling(t *testing.T) {
 
 			batcher := &mocks.Batcher{}
 			batcher.On("Close")
+			batcher.On("Closed").Return(false)
 			batcher.On("Reset")
 			batcher.On("NextBatch").Run(func(arguments mock.Arguments) {
 				time.Sleep(time.Hour)

--- a/test/test_app.go
+++ b/test/test_app.go
@@ -127,10 +127,15 @@ func (a *App) Sync() types.SyncResponse {
 
 // Restart restarts the node
 func (a *App) Restart() {
+	a.RestartSync(true)
+}
+
+func (a *App) RestartSync(sync bool) {
 	a.Consensus.Stop()
 	a.Node.Lock()
 	defer a.Node.Unlock()
 	a.Setup()
+	a.Consensus.Config.SyncOnStart = sync
 	if err := a.Consensus.Start(); err != nil {
 		a.logger.Panicf("Consensus start returned an error : %v", err)
 	}


### PR DESCRIPTION
The leader after a restart would grab the leader token and wait for a non-empty batch. In the new test the view thread of the leader after the restart is just about to call controller decide. However, before the provided fix, the controller is busy waiting for a new batch. Without any new transactions, the leader is stuck. In the fix, if the new batch is empty, the controller continues while reacquiring the leader token, thus allowing the view to call decide.