### PR TITLE
fix select

### DIFF
--- a/internal/bft/viewchanger.go
+++ b/internal/bft/viewchanger.go
@@ -1320,7 +1320,13 @@ func (v *ViewChanger) Decide(proposal types.Proposal, signatures []types.Signatu
 		}
 	}
 	v.Pruner.MaybePruneRevokedRequests()
-	v.inFlightDecideChan <- struct{}{}
+
+	select {
+	case v.inFlightDecideChan <- struct{}{}:
+		return
+	case <-v.stopChan:
+		return
+	}
 }
 
 // Complain panics when a view change is requested


### PR DESCRIPTION
I'm repeatedly running existing tests. Trying to make them more reliable.

On another iteration, I found that one test tries to complete but hangs because of this line:
```
v.inFlightDecideChan <- struct{}{}
```

inFlightDecideChan is a synchronous channel, and it waits "forever" for the subscriber on the other side of the channel.

How to fix this?
Only by rewriting this part of the code to something similar to:
```
select {
case v.inFlightDecideChan <- struct{}{}:
	return
case <-v.stopChan:
	return
}
```