### PR TITLE
fix 2 test - lose commits message

### DIFF
--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -1272,6 +1272,10 @@ func TestLeaderCatchUpWithoutSync(t *testing.T) {
 	restoredWG := sync.WaitGroup{}
 	restoredWG.Add(1)
 
+	var blockCommits uint32
+	nodes[0].LoseMessages(func(msg *smartbftprotos.Message) bool {
+		return msg.GetCommit() != nil && atomic.LoadUint32(&blockCommits) == 1
+	})
 	baseLogger := nodes[0].logger.Desugar()
 	nodes[0].logger = baseLogger.WithOptions(zap.Hooks(func(entry zapcore.Entry) error {
 		if strings.Contains(entry.Message, "Processed prepares for proposal with seq 1") {
@@ -1283,6 +1287,7 @@ func TestLeaderCatchUpWithoutSync(t *testing.T) {
 		return nil
 	})).Sugar()
 	nodes[0].Setup()
+	atomic.StoreUint32(&blockCommits, 1)
 
 	startNodes(nodes, network)
 
@@ -1290,6 +1295,7 @@ func TestLeaderCatchUpWithoutSync(t *testing.T) {
 
 	restartWG.Wait()
 	nodes[0].RestartSync(false)
+	atomic.StoreUint32(&blockCommits, 0)
 	restoredWG.Wait()
 
 	data := make([]*AppRecord, 0)
@@ -1339,6 +1345,10 @@ func TestLeaderProposeAfterRestartWithoutSync(t *testing.T) {
 	contViewWG := sync.WaitGroup{}
 	contViewWG.Add(2)
 
+	var blockCommits uint32
+	nodes[0].LoseMessages(func(msg *smartbftprotos.Message) bool {
+		return msg.GetCommit() != nil && atomic.LoadUint32(&blockCommits) == 1
+	})
 	baseLogger := nodes[0].logger.Desugar()
 	nodes[0].logger = baseLogger.WithOptions(zap.Hooks(func(entry zapcore.Entry) error {
 		if strings.Contains(entry.Message, "Processed prepares for proposal with seq 1") {
@@ -1362,6 +1372,7 @@ func TestLeaderProposeAfterRestartWithoutSync(t *testing.T) {
 		return nil
 	})).Sugar()
 	nodes[0].Setup()
+	atomic.StoreUint32(&blockCommits, 1)
 
 	startNodes(nodes, network)
 
@@ -1369,6 +1380,7 @@ func TestLeaderProposeAfterRestartWithoutSync(t *testing.T) {
 
 	restartWG.Wait()
 	nodes[0].RestartSync(false)
+	atomic.StoreUint32(&blockCommits, 0)
 	restoredWG.Wait()
 
 	nodes[0].Submit(Request{ID: "2", ClientID: "alice"})


### PR DESCRIPTION
Node operation is interrupted after processing prepare messages. 
But we focus on logs. When commit messages may have already arrived.
I added the part that commit messages will definitely not arrive.