### PR TITLE
As of Go 1.21, toolchain versions must use the 1.N.P syntax.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hyperledger-labs/SmartBFT
 
-go 1.22
+go 1.22.3
 
 require (
 	github.com/golang/protobuf v1.5.4


### PR DESCRIPTION
1.22 in go.mod does not match this syntax and there is no additional toolchain directive, which may cause some go commands to fail.

CodeQL also found 1 other warning like this. See the workflow log for details.