### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/internal/bft/requestpool.go
+++ b/internal/bft/requestpool.go
@@ -304,7 +304,7 @@ func (rp *Pool) NextRequests(maxCount int, maxSizeBytes uint64, check bool) (bat
 		}
 	}
 
-	count := minInt(rp.fifo.Len(), maxCount)
+	count := min(rp.fifo.Len(), maxCount)
 	var totalSize uint64
 	batch = make([][]byte, 0, count)
 	element := rp.fifo.Front()

--- a/internal/bft/util.go
+++ b/internal/bft/util.go
@@ -60,13 +60,6 @@ func proposalSequence(m *protos.Message) uint64 {
 	return math.MaxUint64
 }
 
-func minInt(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // MarshalOrPanic marshals or panics when an error occurs
 func MarshalOrPanic(msg proto.Message) []byte {
 	b, err := proto.Marshal(msg)


### PR DESCRIPTION
Use the built-in max/min from the standard library in Go 1.21 to simplify the code.  https://pkg.go.dev/builtin@go1.21.0#max