### PR TITLE
fix error if 2 events occur simultaneously: decision progression and view stopping

### DIFF
--- a/internal/bft/view.go
+++ b/internal/bft/view.go
@@ -1015,6 +1015,10 @@ func (v *View) Stopped() bool {
 	}
 }
 
+func (v *View) AbortChan() <-chan struct{} {
+	return v.abortChan
+}
+
 func (v *View) GetLeaderID() uint64 {
 	return v.LeaderID
 }


### PR DESCRIPTION
On test benches, deadlock of a node is detected due to simultaneous 2 events: decide and abort view.
Added a test that shows this in the current version and a solution to the problem.