### PR TITLE
refactor: use slices.Equal to simplify code

### DIFF
--- a/internal/bft/util.go
+++ b/internal/bft/util.go
@@ -540,20 +540,6 @@ func pruneBlacklist(prevBlacklist []uint64, preparesFrom map[uint64]*protos.Prep
 	return newBlackList
 }
 
-func equalIntLists(a, b []uint64) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	for i := range len(a) {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-
-	return true
-}
-
 func CommitSignaturesDigest(sigs []*protos.Signature) []byte {
 	if len(sigs) == 0 {
 		return nil

--- a/internal/bft/view.go
+++ b/internal/bft/view.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -665,7 +666,7 @@ func (v *View) verifyBlacklist(prevCommitSignatures []*protos.Signature, currVer
 	v.Logger.Debugf("Previous proposal verification sequence: %d, current verification sequence: %d", prevPropRaw.VerificationSequence, currVerificationSeq)
 	if prevPropRaw.VerificationSequence != currVerificationSeq {
 		// If there has been a reconfiguration, black list should remain the same
-		if !equalIntLists(prevProposalMetadata.BlackList, pendingBlacklist) {
+		if !slices.Equal(prevProposalMetadata.BlackList, pendingBlacklist) {
 			return fmt.Errorf("blacklist changed (%v --> %v) during reconfiguration", prevProposalMetadata.BlackList, pendingBlacklist)
 		}
 		v.Logger.Infof("Skipping verifying prev commits due to verification sequence advancing from %d to %d",
@@ -675,7 +676,7 @@ func (v *View) verifyBlacklist(prevCommitSignatures []*protos.Signature, currVer
 
 	if v.MembershipNotifier != nil && v.MembershipNotifier.MembershipChange() {
 		// If there has been a membership change, black list should remain the same
-		if !equalIntLists(prevProposalMetadata.BlackList, pendingBlacklist) {
+		if !slices.Equal(prevProposalMetadata.BlackList, pendingBlacklist) {
 			return fmt.Errorf("blacklist changed (%v --> %v) during membership change", prevProposalMetadata.BlackList, pendingBlacklist)
 		}
 		v.Logger.Infof("Skipping verifying prev commits due to membership change")
@@ -708,7 +709,7 @@ func (v *View) verifyBlacklist(prevCommitSignatures []*protos.Signature, currVer
 	}
 
 	expectedBlacklist := blacklist.computeUpdate()
-	if !equalIntLists(pendingBlacklist, expectedBlacklist) {
+	if !slices.Equal(pendingBlacklist, expectedBlacklist) {
 		return fmt.Errorf("proposed blacklist %v differs from expected %v blacklist", pendingBlacklist, expectedBlacklist)
 	}
 


### PR DESCRIPTION
In the Go 1.21 standard library, a new function has been introduced that enhances code conciseness and readability. It can be find [here](https://pkg.go.dev/slices@go1.21.1#Equal).