### PR TITLE
refactor: remove redundant variable declarations in for loops

### DIFF
--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -1191,7 +1191,6 @@ func TestLeaderModifiesPreprepare(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 		t.Run(test.description, func(t *testing.T) {
 			t.Parallel()
 			network := NewNetwork()


### PR DESCRIPTION
The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore