### PR TITLE
Avoid blocking on completion signals when the waiter has left

### DIFF
--- a/internal/bft/completion_signal_test.go
+++ b/internal/bft/completion_signal_test.go
@@ -1,0 +1,98 @@
+// Copyright IBM Corp. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package bft
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hyperledger-labs/SmartBFT/pkg/types"
+	protos "github.com/hyperledger-labs/SmartBFT/smartbftprotos"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestControllerDecideDoesNotBlockIfDeliveryWaiterLeft(t *testing.T) {
+	metadata, err := proto.Marshal(&protos.ViewMetadata{})
+	assert.NoError(t, err)
+
+	checkpoint := &types.Checkpoint{}
+	checkpoint.Set(types.Proposal{Metadata: metadata}, nil)
+
+	controller := &Controller{
+		ID:         2,
+		N:          4,
+		NodesList:  []uint64{1, 2, 3, 4},
+		Logger:     zap.NewNop().Sugar(),
+		Deliver:    applicationFunc(func(types.Proposal, []types.Signature) types.Reconfig { return types.Reconfig{} }),
+		Verifier:   noopVerifier{},
+		Checkpoint: checkpoint,
+		stopChan:   make(chan struct{}),
+	}
+
+	requireReturns(t, func() {
+		controller.decide(decision{
+			proposal:  types.Proposal{Metadata: metadata},
+			delivered: make(chan struct{}),
+		})
+	})
+}
+
+func requireReturns(t *testing.T, f func()) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		f()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("function blocked")
+	}
+}
+
+// These tests live in package bft to reach unexported completion paths, so they
+// cannot use internal/bft/mocks without creating an import cycle.
+
+type applicationFunc func(types.Proposal, []types.Signature) types.Reconfig
+
+func (f applicationFunc) Deliver(proposal types.Proposal, signatures []types.Signature) types.Reconfig {
+	return f(proposal, signatures)
+}
+
+type noopVerifier struct{}
+
+func (noopVerifier) VerificationSequence() uint64 {
+	return 0
+}
+
+func (noopVerifier) VerifyProposal(types.Proposal) ([]types.RequestInfo, error) {
+	panic("unexpected VerifyProposal call")
+}
+
+func (noopVerifier) VerifyRequest([]byte) (types.RequestInfo, error) {
+	panic("unexpected VerifyRequest call")
+}
+
+func (noopVerifier) VerifyConsenterSig(types.Signature, types.Proposal) ([]byte, error) {
+	panic("unexpected VerifyConsenterSig call")
+}
+
+func (noopVerifier) VerifySignature(types.Signature) error {
+	panic("unexpected VerifySignature call")
+}
+
+func (noopVerifier) RequestsFromProposal(types.Proposal) []types.RequestInfo {
+	panic("unexpected RequestsFromProposal call")
+}
+
+func (noopVerifier) AuxiliaryData([]byte) []byte {
+	panic("unexpected AuxiliaryData call")
+}

--- a/internal/bft/completion_signal_test.go
+++ b/internal/bft/completion_signal_test.go
@@ -42,6 +42,44 @@ func TestControllerDecideDoesNotBlockIfDeliveryWaiterLeft(t *testing.T) {
 	})
 }
 
+func TestViewChangerDecideDoesNotBlockIfInFlightWaiterLeft(t *testing.T) {
+	inFlightView := &View{abortChan: make(chan struct{})}
+
+	viewChanger := &ViewChanger{
+		Logger:        zap.NewNop().Sugar(),
+		Application:   applicationFunc(func(types.Proposal, []types.Signature) types.Reconfig { return types.Reconfig{} }),
+		RequestsTimer: noopRequestsTimer{},
+		Pruner:        noopPruner{},
+		// Unbuffered and unread: the attempt's waiter has already left.
+		inFlightAttempt: &inFlightAttempt{
+			id:       1,
+			decideCh: make(chan struct{}),
+			syncCh:   make(chan struct{}),
+			viewRef:  inFlightView,
+		},
+		inFlightView: inFlightView,
+	}
+
+	requireReturns(t, func() {
+		viewChanger.Decide(types.Proposal{}, nil, nil)
+	})
+}
+
+func TestViewChangerSyncDoesNotBlockIfInFlightWaiterLeft(t *testing.T) {
+	viewChanger := &ViewChanger{
+		Logger:       zap.NewNop().Sugar(),
+		Synchronizer: synchronizerFunc(func() {}),
+		// Unbuffered and unread: the attempt's waiter has already left.
+		inFlightAttempt: &inFlightAttempt{
+			id:       1,
+			decideCh: make(chan struct{}),
+			syncCh:   make(chan struct{}),
+		},
+	}
+
+	requireReturns(t, viewChanger.Sync)
+}
+
 func requireReturns(t *testing.T, f func()) {
 	t.Helper()
 
@@ -95,4 +133,24 @@ func (noopVerifier) RequestsFromProposal(types.Proposal) []types.RequestInfo {
 
 func (noopVerifier) AuxiliaryData([]byte) []byte {
 	panic("unexpected AuxiliaryData call")
+}
+
+type noopRequestsTimer struct{}
+
+func (noopRequestsTimer) StopTimers() {}
+
+func (noopRequestsTimer) RestartTimers() {}
+
+func (noopRequestsTimer) RemoveRequest(types.RequestInfo) error {
+	return nil
+}
+
+type noopPruner struct{}
+
+func (noopPruner) MaybePruneRevokedRequests() {}
+
+type synchronizerFunc func()
+
+func (f synchronizerFunc) Sync() {
+	f()
 }

--- a/internal/bft/controller.go
+++ b/internal/bft/controller.go
@@ -132,7 +132,6 @@ type Controller struct {
 
 	syncChan             chan struct{}
 	decisionChan         chan decision
-	deliverChan          chan struct{}
 	leaderToken          chan struct{}
 	verificationSequence atomic.Uint64
 
@@ -542,9 +541,10 @@ func (c *Controller) decide(d decision) {
 	}
 	c.Logger.Debugf("Node %d delivered proposal", c.ID)
 	c.removeDeliveredFromPool(d)
-	select {
-	case c.deliverChan <- struct{}{}:
-	case <-c.stopChan:
+	if d.delivered != nil {
+		close(d.delivered)
+	}
+	if c.stopped() {
 		return
 	}
 	c.incrementCurrentDecisionsInView()
@@ -797,7 +797,6 @@ func (c *Controller) Start(startViewNumber uint64, startProposalSequence uint64,
 	c.stopChan = make(chan struct{})
 	c.leaderToken = make(chan struct{}, 1)
 	c.decisionChan = make(chan decision, 1)
-	c.deliverChan = make(chan struct{})
 	c.viewChange = make(chan viewInfo, 1)
 	c.abortViewChan = make(chan uint64, 1)
 
@@ -882,11 +881,13 @@ func (c *Controller) stopped() bool {
 
 // Decide delivers the decision to the application
 func (c *Controller) Decide(proposal types.Proposal, signatures []types.Signature, requests []types.RequestInfo) {
+	delivered := make(chan struct{})
 	select {
 	case c.decisionChan <- decision{
 		proposal:   proposal,
 		requests:   requests,
 		signatures: signatures,
+		delivered:  delivered,
 	}:
 	case <-c.stopChan:
 		// In case we are in the middle of shutting down,
@@ -895,7 +896,7 @@ func (c *Controller) Decide(proposal types.Proposal, signatures []types.Signatur
 	}
 
 	select {
-	case <-c.deliverChan: // wait for the delivery of the decision to the application
+	case <-delivered: // wait for the delivery of the decision to the application
 	case <-c.stopChan: // If we stopped the controller, abort delivery
 	case <-c.currentViewAbortChan(): // If we stopped the view, abort delivery
 	}
@@ -918,6 +919,7 @@ type decision struct {
 	proposal   types.Proposal
 	signatures []types.Signature
 	requests   []types.RequestInfo
+	delivered  chan struct{}
 }
 
 // BroadcastConsensus broadcasts the message and informs the heartbeat monitor if necessary

--- a/internal/bft/viewchanger.go
+++ b/internal/bft/viewchanger.go
@@ -48,6 +48,28 @@ type change struct {
 	stopView bool
 }
 
+type inFlightAttempt struct {
+	id       uint64
+	view     uint64
+	sequence uint64
+	decideCh chan struct{}
+	syncCh   chan struct{}
+	viewRef  *View
+}
+
+type inFlightAttemptCallbacks struct {
+	vc      *ViewChanger
+	attempt *inFlightAttempt
+}
+
+func (c *inFlightAttemptCallbacks) Decide(proposal types.Proposal, signatures []types.Signature, requests []types.RequestInfo) {
+	c.vc.decideInFlight(c.attempt, proposal, signatures, requests)
+}
+
+func (c *inFlightAttemptCallbacks) Sync() {
+	c.vc.syncInFlight(c.attempt)
+}
+
 // ViewChanger is responsible for running the view change protocol.
 type ViewChanger struct {
 	// Configuration
@@ -77,8 +99,8 @@ type ViewChanger struct {
 
 	// for the in flight proposal view
 	ViewSequences      *atomic.Value
-	inFlightDecideChan chan struct{}
-	inFlightSyncChan   chan struct{}
+	inFlightAttemptSeq uint64
+	inFlightAttempt    *inFlightAttempt
 	inFlightView       *View
 	inFlightViewLock   sync.RWMutex
 
@@ -147,9 +169,6 @@ func (v *ViewChanger) Start(startViewNumber uint64) {
 	v.lastResend = v.lastTick
 
 	v.backOffFactor = 1
-
-	v.inFlightDecideChan = make(chan struct{})
-	v.inFlightSyncChan = make(chan struct{})
 
 	go func() {
 		defer v.vcDone.Done()
@@ -1219,6 +1238,18 @@ func (v *ViewChanger) commitInFlightProposal(proposal *protos.Proposal) (success
 	inFlightViewLatestSeq := proposalMD.LatestSequence
 
 	v.inFlightViewLock.Lock()
+	v.inFlightAttemptSeq++
+	attempt := &inFlightAttempt{
+		id:       v.inFlightAttemptSeq,
+		view:     inFlightViewNum,
+		sequence: inFlightViewLatestSeq,
+		decideCh: make(chan struct{}, 1),
+		syncCh:   make(chan struct{}, 1),
+	}
+	callbacks := &inFlightAttemptCallbacks{
+		vc:      v,
+		attempt: attempt,
+	}
 	inFlightView := &View{
 		RetrieveCheckpoint: v.Checkpoint.Get,
 		DecisionsPerLeader: v.DecisionsPerLeader,
@@ -1228,9 +1259,9 @@ func (v *ViewChanger) commitInFlightProposal(proposal *protos.Proposal) (success
 		Number:             inFlightViewNum,
 		LeaderID:           v.SelfID, // so that no byzantine leader will cause a complain
 		Quorum:             v.quorum,
-		Decider:            v,
+		Decider:            callbacks,
 		FailureDetector:    v,
-		Sync:               v,
+		Sync:               callbacks,
 		Logger:             v.Logger,
 		Comm:               v.Comm,
 		Verifier:           v.Verifier,
@@ -1243,6 +1274,7 @@ func (v *ViewChanger) commitInFlightProposal(proposal *protos.Proposal) (success
 		MetricsBlacklist:   v.MetricsBlacklist,
 		MetricsView:        v.MetricsView,
 	}
+	attempt.viewRef = inFlightView
 	inFlightView.MetricsView.ViewNumber.Set(float64(inFlightView.Number))
 	inFlightView.MetricsView.LeaderID.Set(float64(inFlightView.LeaderID))
 	inFlightView.MetricsView.ProposalSequence.Set(float64(inFlightView.ProposalSequence))
@@ -1250,6 +1282,7 @@ func (v *ViewChanger) commitInFlightProposal(proposal *protos.Proposal) (success
 	inFlightView.MetricsView.Phase.Set(float64(inFlightView.Phase))
 
 	v.inFlightView = inFlightView
+	v.inFlightAttempt = attempt
 	v.inFlightView.inFlightProposal = &types.Proposal{
 		VerificationSequence: int64(proposal.VerificationSequence),
 		Metadata:             proposal.Metadata,
@@ -1277,7 +1310,17 @@ func (v *ViewChanger) commitInFlightProposal(proposal *protos.Proposal) (success
 	<-v.Ticker
 
 	inFlightView.Start()
-	defer inFlightView.Abort()
+	defer func() {
+		inFlightView.Abort()
+		v.inFlightViewLock.Lock()
+		if v.inFlightAttempt == attempt {
+			v.inFlightAttempt = nil
+		}
+		if v.inFlightView == inFlightView {
+			v.inFlightView = nil
+		}
+		v.inFlightViewLock.Unlock()
+	}()
 
 	v.inFlightViewLock.Unlock()
 
@@ -1286,10 +1329,10 @@ func (v *ViewChanger) commitInFlightProposal(proposal *protos.Proposal) (success
 	// wait for view to finish or time out
 	for {
 		select {
-		case <-v.inFlightDecideChan:
+		case <-attempt.decideCh:
 			v.Logger.Infof("In-flight view %d with latest sequence %d has committed a decision", inFlightViewNum, inFlightViewLatestSeq)
 			return true
-		case <-v.inFlightSyncChan:
+		case <-attempt.syncCh:
 			v.Logger.Infof("In-flight view %d with latest sequence %d has asked to sync", inFlightViewNum, inFlightViewLatestSeq)
 			return false
 		case now := <-v.Ticker:
@@ -1305,9 +1348,22 @@ func (v *ViewChanger) commitInFlightProposal(proposal *protos.Proposal) (success
 	}
 }
 
-// Decide delivers to the application and informs the view changer after delivery
+func (v *ViewChanger) currentInFlightAttempt() *inFlightAttempt {
+	v.inFlightViewLock.RLock()
+	defer v.inFlightViewLock.RUnlock()
+	return v.inFlightAttempt
+}
+
+// Decide delivers to the application and informs the view changer after delivery.
+// It is kept for compatibility; in-flight views use per-attempt callbacks.
 func (v *ViewChanger) Decide(proposal types.Proposal, signatures []types.Signature, requests []types.RequestInfo) {
-	v.inFlightView.stop()
+	v.decideInFlight(v.currentInFlightAttempt(), proposal, signatures, requests)
+}
+
+func (v *ViewChanger) decideInFlight(attempt *inFlightAttempt, proposal types.Proposal, signatures []types.Signature, requests []types.RequestInfo) {
+	if attempt != nil && attempt.viewRef != nil {
+		attempt.viewRef.stop()
+	}
 	v.Logger.Debugf("Delivering to app from Decide the last decision proposal")
 	reconfig := v.Application.Deliver(proposal, signatures)
 	if reconfig.InLatestDecision {
@@ -1322,8 +1378,13 @@ func (v *ViewChanger) Decide(proposal types.Proposal, signatures []types.Signatu
 	}
 	v.Pruner.MaybePruneRevokedRequests()
 
+	if attempt == nil {
+		return
+	}
 	select {
-	case v.inFlightDecideChan <- struct{}{}:
+	case attempt.decideCh <- struct{}{}:
+		return
+	default:
 		return
 	case <-v.stopChan:
 		return
@@ -1335,12 +1396,23 @@ func (v *ViewChanger) Complain(viewNum uint64, stopView bool) {
 	v.Logger.Panicf("Node %d has complained while in the view for the in flight proposal", v.SelfID)
 }
 
-// Sync calls the synchronizer and informs the view changer of the sync
+// Sync calls the synchronizer and informs the view changer of the sync.
+// It is kept for compatibility; in-flight views use per-attempt callbacks.
 func (v *ViewChanger) Sync() {
+	v.syncInFlight(v.currentInFlightAttempt())
+}
+
+func (v *ViewChanger) syncInFlight(attempt *inFlightAttempt) {
 	// the in flight proposal view asked to sync
 	v.Logger.Debugf("Node %d is calling sync because the in flight proposal view has asked to sync", v.SelfID)
 	v.Synchronizer.Sync()
-	v.inFlightSyncChan <- struct{}{}
+	if attempt == nil {
+		return
+	}
+	select {
+	case attempt.syncCh <- struct{}{}:
+	default:
+	}
 }
 
 // HandleViewMessage passes a message to the in flight proposal view if applicable


### PR DESCRIPTION
The controller and the view changer both used unbuffered channels to report completion, where the receiver can legitimately stop waiting and leave the sender blocked forever.

Controller: `Decide` stops waiting on `deliverChan` when the view aborts, but `decide` was still blocked sending on it, so the run loop stalled until shutdown. Now uses a per-decision `delivered` channel closed after delivery. In the aborted case `decide` no longer returns early, so the decision-count increment, rotation check, pruning and leader-token acquisition now run, since the decision was in fact delivered.

View changer: once `commitInFlightProposal` returned via timeout or stop, nothing read `inFlightDecideChan` or `inFlightSyncChan`. A late `Decide` or `Sync` then blocked the in-flight view's run goroutine, which blocked `Abort()` since it waits on that goroutine, which blocked the view changer in its own cleanup. No later attempt could start to drain the channel. `Decide` could at least escape on `stopChan`, while `Sync` had no escape at all. Now each attempt owns an `inFlightAttempt` holding its own buffered `decideCh` and `syncCh`, cleared when the attempt ends, with non-blocking sends. The in-flight view's `Decider` and `Sync` are callbacks bound to that attempt at creation, so a late `Decide` or `Sync` can only signal its own attempt and cannot disturb a later one.

Adds regression tests for all three completion paths.